### PR TITLE
[Feat] 카카오 로그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // OpenFeign
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
@@ -71,6 +72,7 @@ dependencies {
 
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -1,0 +1,93 @@
+package com.whatever.config
+
+import com.whatever.domain.user.dto.UserStatus
+import com.whatever.global.security.filter.JwtAuthenticationFilter
+import com.whatever.global.security.filter.JwtExceptionFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
+
+@EnableMethodSecurity
+@EnableWebSecurity
+@Configuration
+class SecurityConfig(
+    private val jwtAuthenticationFilter: JwtAuthenticationFilter,
+    private val jwtExceptionFilter: JwtExceptionFilter,
+    private val caramelAuthenticationEntryPoint: AuthenticationEntryPoint,
+    private val caramelAccessDeniedHandler: AccessDeniedHandler
+) {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http.invoke {
+            httpBasic { disable() }
+            formLogin { disable() }
+            logout { disable() }
+            csrf { disable() }
+            cors { disable() }
+        }
+
+        http.sessionManagement{ it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+
+        http.invoke {
+            authorizeHttpRequests {
+                authorize(anyRequest, permitAll)  // TODO(준용) API에 따른 Role 추가 필요, 현재 임시로 모두 허용
+            }
+        }
+
+        http.invoke {
+            addFilterBefore<BasicAuthenticationFilter>(jwtAuthenticationFilter)
+            addFilterBefore<JwtAuthenticationFilter>(jwtExceptionFilter)
+        }
+
+        http.invoke {
+            exceptionHandling {
+                authenticationEntryPoint = caramelAuthenticationEntryPoint
+                accessDeniedHandler = caramelAccessDeniedHandler
+            }
+        }
+
+        return http.build()
+    }
+
+    @Bean
+    fun webSecurityCustomizer(): WebSecurityCustomizer {
+        return WebSecurityCustomizer {
+            it.ignoring().requestMatchers(
+                "/swagger",
+                "/swagger-ui/**",
+                "/swagger-resources/**",
+                "/v3/api-docs/**"
+            )
+        }
+    }
+
+    @Bean
+    fun roleHierarchy(): RoleHierarchy {
+        return RoleHierarchyImpl.withDefaultRolePrefix()
+            .role(UserStatus.COUPLED.name).implies(UserStatus.SINGLE.name)
+            .role(UserStatus.SINGLE.name).implies(UserStatus.NEW.name)
+            .build()
+    }
+
+    @Bean
+    fun methodSecurityExpressionHandler(): MethodSecurityExpressionHandler {
+        val expressionHandler = DefaultMethodSecurityExpressionHandler()
+        expressionHandler.setRoleHierarchy(roleHierarchy())
+        return expressionHandler
+    }
+
+}

--- a/src/main/kotlin/com/whatever/domain/auth/client/dto/KakaoUserInfoDto.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/client/dto/KakaoUserInfoDto.kt
@@ -8,7 +8,10 @@ data class KakaoUserInfoResponse(
     val id: Long,
     val kakaoAccount: KakaoAccount,
     val properties: KakaoUserProperties? = null,
-)
+) {
+    val platformUserId
+        get() = id.toString()
+}
 
 @JsonNaming(SnakeCaseStrategy::class)
 data class KakaoAccount(

--- a/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
@@ -34,7 +34,7 @@ class AuthController(
         loginPlatform: LoginPlatform,
         accessToken: String,
     ): CaramelApiResponse<SocialAuthResponse> {
-        val socialAuthResponse = authService.signUp(loginPlatform, accessToken)
+        val socialAuthResponse = authService.signUpOrSignIn(loginPlatform, accessToken)
         return socialAuthResponse.succeed()
     }
 }

--- a/src/main/kotlin/com/whatever/domain/auth/exception/AuthException.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/exception/AuthException.kt
@@ -1,0 +1,14 @@
+package com.whatever.domain.auth.exception
+
+import com.whatever.global.exception.common.CaramelException
+
+open class AuthException(
+    errorCode: AuthExceptionCode,
+    detailMessage: String? = null
+) : CaramelException(errorCode, detailMessage)
+
+class AuthFailedException(
+    errorCode: AuthExceptionCode,
+    detailMessage: String? = null
+) : AuthException(errorCode, detailMessage)
+

--- a/src/main/kotlin/com/whatever/domain/auth/exception/AuthExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/exception/AuthExceptionCode.kt
@@ -1,0 +1,17 @@
+package com.whatever.domain.auth.exception
+
+import com.whatever.global.exception.common.CaramelExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class AuthExceptionCode(
+    sequence: String,
+    override val message: String,
+    override val status: HttpStatus = HttpStatus.BAD_REQUEST,
+) : CaramelExceptionCode {
+
+    UNKNOWN( "000", "알 수 없는 에러입니다. 담당자에게 문의해주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    USER_NOT_FOUND( "001", "해당 소셜 계정으로 가입된 유저가 없습니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    override val code = "AUTH$sequence"
+}

--- a/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
@@ -27,30 +27,30 @@ class AuthService(
         loginPlatform: LoginPlatform,
         accessToken: String,
     ): SocialAuthResponse {
-        return when (loginPlatform) {
+        val userId = when (loginPlatform) {
             LoginPlatform.KAKAO -> {
-                getKakaoResponse(accessToken = accessToken)
+                persistUserByKakao(kakaoAccessToken = accessToken)
             }
 
             LoginPlatform.APPLE -> {
-                getAppleAccessToken(accessToken = accessToken)
+                persistUserByApple(appleAccessToken = accessToken)
             }
 
             else -> {
                 throw GlobalException(GlobalExceptionCode.ARGS_VALIDATION_FAILED)
             }
         }
-    }
-
-    private fun getKakaoResponse(accessToken: String): SocialAuthResponse {
-        val kakaoUserInfoResponse = kakaoOAuthClient.getUserInfo(accessToken)
-        val user = userRepository.save(kakaoUserInfoResponse.toUser())
-        val userId = user.id ?: throw GlobalException(GlobalExceptionCode.ARGS_VALIDATION_FAILED)
 
         return createTokenAndSave(userId = userId)
     }
 
-    private fun getAppleAccessToken(accessToken: String): SocialAuthResponse {
+    private fun persistUserByKakao(kakaoAccessToken: String): Long {
+        val kakaoUserInfoResponse = kakaoOAuthClient.getUserInfo(kakaoAccessToken)
+        val user = userRepository.save(kakaoUserInfoResponse.toUser())
+        return user.id ?: throw GlobalException(GlobalExceptionCode.ARGS_VALIDATION_FAILED)
+    }
+
+    private fun persistUserByApple(appleAccessToken: String): Long {
         // TODO: 애플 로그인 구현 필요
         throw IllegalStateException("애플 로그인 미구현")
     }

--- a/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
@@ -69,6 +69,7 @@ class AuthService(
 
 private fun KakaoUserInfoResponse.toUser() = User(
     platform = LoginPlatform.KAKAO,
+    platformUserId = platformUserId,
     nickname = kakaoAccount.profile.nickname,
     email = kakaoAccount.email,
     birthDate = if (kakaoAccount.birthYear != null && kakaoAccount.birthDay != null) {

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/AppleUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/AppleUserProvider.kt
@@ -1,0 +1,17 @@
+package com.whatever.domain.auth.service.provider
+
+import com.whatever.domain.user.model.LoginPlatform
+import com.whatever.domain.user.model.User
+import org.springframework.stereotype.Component
+
+@Component
+class AppleUserProvider : SocialUserProvider {
+
+    override val platform: LoginPlatform
+        get() = LoginPlatform.APPLE
+
+    override fun findOrCreateUser(socialAccessToken: String): User {
+        // TODO(준용): Apple 유저
+        throw IllegalStateException("미구현된 기능합니다.")
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProvider.kt
@@ -1,0 +1,41 @@
+package com.whatever.domain.auth.service.provider
+
+import com.whatever.domain.auth.client.KakaoOAuthClient
+import com.whatever.domain.auth.client.dto.KakaoUserInfoResponse
+import com.whatever.domain.user.model.LoginPlatform
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.repository.UserRepository
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+
+@Component
+class KakaoUserProvider(
+    private val kakaoOAuthClient: KakaoOAuthClient,
+    private val userRepository: UserRepository,
+) : SocialUserProvider {
+
+    override val platform: LoginPlatform
+        get() = LoginPlatform.KAKAO
+
+    override fun findOrCreateUser(socialAccessToken: String): User {
+        val userInfo = kakaoOAuthClient.getUserInfo(socialAccessToken)
+        return userRepository.findByPlatformUserId(userInfo.platformUserId)
+            ?: userRepository.save(userInfo.toUser())
+    }
+}
+
+private fun KakaoUserInfoResponse.toUser() = User(
+    platform = LoginPlatform.KAKAO,
+    platformUserId = platformUserId,
+    nickname = kakaoAccount.profile.nickname,
+    email = kakaoAccount.email,
+    birthDate = if (kakaoAccount.birthYear != null && kakaoAccount.birthDay != null) {
+        LocalDate.of(
+            kakaoAccount.birthYear.toInt(),
+            kakaoAccount.birthDay.take(2).toInt(),
+            kakaoAccount.birthDay.takeLast(2).toInt()
+        )
+    } else {
+        null
+    }
+)

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/SocialUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/SocialUserProvider.kt
@@ -1,0 +1,13 @@
+package com.whatever.domain.auth.service.provider
+
+import com.whatever.domain.user.model.LoginPlatform
+import com.whatever.domain.user.model.User
+
+interface SocialUserProvider {
+    val platform: LoginPlatform
+
+    /**
+     * 각 플랫폼의 AccessToken을 사용하여 가입된 User를 찾거나, 새로운 User를 저장하여 반환합니다.
+     */
+    fun findOrCreateUser(socialAccessToken: String): User
+}

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -20,6 +20,8 @@ class User(
     @Enumerated(EnumType.STRING)
     val platform: LoginPlatform,
 
+    val platformUserId: String,
+
     var nickname: String? = null,
 
     var gender: String? = null,

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -20,6 +20,7 @@ class User(
     @Enumerated(EnumType.STRING)
     val platform: LoginPlatform,
 
+    @Column(unique = true)
     val platformUserId: String,
 
     var nickname: String? = null,

--- a/src/main/kotlin/com/whatever/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/user/repository/UserRepository.kt
@@ -4,4 +4,5 @@ import com.whatever.domain.user.model.User
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
+    fun findByPlatformUserId(platformUserId: String): User?
 }

--- a/src/main/kotlin/com/whatever/global/exception/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/com/whatever/global/exception/GlobalControllerAdvice.kt
@@ -3,6 +3,7 @@ package com.whatever.global.exception
 import com.whatever.global.exception.common.CaramelControllerAdvice
 import com.whatever.global.exception.common.CaramelException
 import com.whatever.global.exception.dto.CaramelApiResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.ServletException
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.ResponseEntity
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.HandlerMethodValidationException
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.servlet.resource.NoResourceFoundException
+
+private val logger = KotlinLogging.logger {  }
 
 @RestControllerAdvice
 class GlobalControllerAdvice : CaramelControllerAdvice() {
@@ -63,7 +66,7 @@ class GlobalControllerAdvice : CaramelControllerAdvice() {
 
     @ExceptionHandler(Exception::class)
     fun handleApplicationException(e: Exception): ResponseEntity<CaramelApiResponse<*>> {
-        println("->>> $e")
+        logger.error(e) { "예상하지 못한 예외가 발생했습니다." }
         return createExceptionResponse(errorCode = GlobalExceptionCode.UNKNOWN)
     }
 

--- a/src/main/kotlin/com/whatever/global/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/JwtProvider.kt
@@ -3,11 +3,18 @@ package com.whatever.global.jwt
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.whatever.config.properties.JwtProperties
+import com.whatever.global.jwt.exception.*
 import com.whatever.util.DateTimeUtil
 import com.whatever.util.toDate
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.jsonwebtoken.*
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.security.SecurityException
+import io.jsonwebtoken.security.SignatureException
 import org.springframework.stereotype.Component
 import java.util.*
+
+private val logger = KotlinLogging.logger {  }
 
 @Component
 class JwtProvider(
@@ -36,12 +43,24 @@ class JwtProvider(
     fun parseJwt(jwtParser: JwtParser, token: String): Jws<Claims> {
         try {
             return jwtParser.parseSignedClaims(token)
-
-            // TODO(준용) CustomException으로 변경
+        } catch (e: MalformedJwtException) {
+            logger.error(e) { "MalformedJwtException 발생 - 토큰 형식이 잘못되었습니다. 토큰: ${token}" }
+            throw JwtMalformedException(JwtExceptionCode.MALFORMED)
+        } catch (e: SignatureException) {
+            logger.error(e) { "SignatureException 발생 - JWT 서명 검증에 실패했습니다. 토큰: ${token}" }
+            throw JwtSignatureException(JwtExceptionCode.SIGNATURE_INVALID)
+        } catch (e: SecurityException) {
+            logger.error(e) { "SecurityException 발생 - JWT 암호 해독에 실패했습니다. 토큰: ${token}" }
+            throw JwtSecurityException(JwtExceptionCode.SECURITY_FAILURE)
+        } catch (e: ExpiredJwtException) {
+            logger.error(e) { "ExpiredJwtException 발생 - JWT가 만료되었습니다. 종류: ${e.claims.subject} 만료시간: ${e.claims.expiration}" }
+            throw JwtExpiredException(JwtExceptionCode.EXPIRED)
         } catch (e: UnsupportedJwtException) {
-            throw IllegalArgumentException("서명되지 않았거나 지원되지 않는 JWT 형식입니다.")
+            logger.error(e) { "UnsupportedJwtException 발생 - 지원되지 않는 JWT 형식입니다. 토큰: ${token}" }
+            throw JwtUnsupportedException(JwtExceptionCode.UNSUPPORTED)
         } catch (e: JwtException) {
-            throw IllegalArgumentException("JWT를 파싱하거나 검증하는 과정에서 오류가 발생했습니다.")
+            logger.error(e) { "JwtException 발생 - JWT 파싱 또는 검증 중 오류가 발생했습니다. 토큰: ${token}" }
+            throw CaramelJwtException(JwtExceptionCode.UNKNOWN)
         }
     }
 
@@ -57,8 +76,7 @@ class JwtProvider(
     private fun getJwtChunk(token: String): List<String> {
         val jwtChunk = token.split(Regex.fromLiteral("."))
         if (jwtChunk.size < 3) {
-            // TODO(준용) CustomException으로 변경
-            throw IllegalArgumentException("올바르지 않은 JWT 형식입니다.")
+            throw JwtMalformedException(JwtExceptionCode.MALFORMED)
         }
         return jwtChunk
     }

--- a/src/main/kotlin/com/whatever/global/jwt/JwtProvider.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/JwtProvider.kt
@@ -45,22 +45,22 @@ class JwtProvider(
             return jwtParser.parseSignedClaims(token)
         } catch (e: MalformedJwtException) {
             logger.error(e) { "MalformedJwtException 발생 - 토큰 형식이 잘못되었습니다. 토큰: ${token}" }
-            throw JwtMalformedException(JwtExceptionCode.MALFORMED)
+            throw JwtMalformedException(JwtExceptionCode.PARSE_FAILED)
         } catch (e: SignatureException) {
             logger.error(e) { "SignatureException 발생 - JWT 서명 검증에 실패했습니다. 토큰: ${token}" }
-            throw JwtSignatureException(JwtExceptionCode.SIGNATURE_INVALID)
+            throw JwtSignatureException(JwtExceptionCode.PARSE_FAILED)
         } catch (e: SecurityException) {
             logger.error(e) { "SecurityException 발생 - JWT 암호 해독에 실패했습니다. 토큰: ${token}" }
-            throw JwtSecurityException(JwtExceptionCode.SECURITY_FAILURE)
+            throw JwtSecurityException(JwtExceptionCode.PARSE_FAILED)
         } catch (e: ExpiredJwtException) {
             logger.error(e) { "ExpiredJwtException 발생 - JWT가 만료되었습니다. 종류: ${e.claims.subject} 만료시간: ${e.claims.expiration}" }
-            throw JwtExpiredException(JwtExceptionCode.EXPIRED)
+            throw JwtExpiredException(JwtExceptionCode.PARSE_FAILED)
         } catch (e: UnsupportedJwtException) {
             logger.error(e) { "UnsupportedJwtException 발생 - 지원되지 않는 JWT 형식입니다. 토큰: ${token}" }
-            throw JwtUnsupportedException(JwtExceptionCode.UNSUPPORTED)
+            throw JwtUnsupportedException(JwtExceptionCode.PARSE_FAILED)
         } catch (e: JwtException) {
             logger.error(e) { "JwtException 발생 - JWT 파싱 또는 검증 중 오류가 발생했습니다. 토큰: ${token}" }
-            throw CaramelJwtException(JwtExceptionCode.UNKNOWN)
+            throw CaramelJwtException(JwtExceptionCode.PARSE_FAILED)
         }
     }
 

--- a/src/main/kotlin/com/whatever/global/jwt/exception/JwtException.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/exception/JwtException.kt
@@ -1,0 +1,33 @@
+package com.whatever.global.jwt.exception
+
+import com.whatever.global.exception.common.CaramelException
+
+open class CaramelJwtException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelException(errorCode, detailMessage)
+
+class JwtMalformedException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelJwtException(errorCode)
+
+class JwtSignatureException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelJwtException(errorCode)
+
+class JwtSecurityException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelJwtException(errorCode)
+
+class JwtExpiredException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelJwtException(errorCode)
+
+class JwtUnsupportedException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelJwtException(errorCode)

--- a/src/main/kotlin/com/whatever/global/jwt/exception/JwtException.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/exception/JwtException.kt
@@ -31,3 +31,8 @@ class JwtUnsupportedException(
     errorCode: JwtExceptionCode,
     detailMessage: String? = null
 ) : CaramelJwtException(errorCode)
+
+class JwtMissingClaimException(
+    errorCode: JwtExceptionCode,
+    detailMessage: String? = null
+) : CaramelJwtException(errorCode)

--- a/src/main/kotlin/com/whatever/global/jwt/exception/JwtExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/exception/JwtExceptionCode.kt
@@ -15,6 +15,7 @@ enum class JwtExceptionCode(
     SECURITY_FAILURE("003", "JWT 암호 해독에 실패했습니다."),
     EXPIRED("004", "JWT가 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     UNSUPPORTED("005", "지원되지 않는 JWT 형식입니다."),
+    MISSING_CLAIM("006", "JWT에 필요한 정보가 없습니다.")
     ;
 
     override val code = "JWT$sequence"

--- a/src/main/kotlin/com/whatever/global/jwt/exception/JwtExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/exception/JwtExceptionCode.kt
@@ -1,0 +1,21 @@
+package com.whatever.global.jwt.exception
+
+import com.whatever.global.exception.common.CaramelExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class JwtExceptionCode(
+    sequence: String,
+    override val message: String,
+    override val status: HttpStatus = HttpStatus.BAD_REQUEST,
+) : CaramelExceptionCode {
+
+    UNKNOWN("000", "JWT를 파싱하거나 검증하는 과정에서 예상치 못한 오류가 발생했습니다."),
+    MALFORMED("001", "JWT 형식이 잘못되었습니다."),
+    SIGNATURE_INVALID("002", "JWT 서명 검증에 실패했습니다."),
+    SECURITY_FAILURE("003", "JWT 암호 해독에 실패했습니다."),
+    EXPIRED("004", "JWT가 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    UNSUPPORTED("005", "지원되지 않는 JWT 형식입니다."),
+    ;
+
+    override val code = "JWT$sequence"
+}

--- a/src/main/kotlin/com/whatever/global/jwt/exception/JwtExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/jwt/exception/JwtExceptionCode.kt
@@ -15,7 +15,8 @@ enum class JwtExceptionCode(
     SECURITY_FAILURE("003", "JWT 암호 해독에 실패했습니다."),
     EXPIRED("004", "JWT가 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     UNSUPPORTED("005", "지원되지 않는 JWT 형식입니다."),
-    MISSING_CLAIM("006", "JWT에 필요한 정보가 없습니다.")
+    MISSING_CLAIM("006", "JWT에 필요한 정보가 없습니다."),
+    PARSE_FAILED("007", "인증 토큰이 유효하지 않습니다.")
     ;
 
     override val code = "JWT$sequence"

--- a/src/main/kotlin/com/whatever/global/security/exception/SecurityException.kt
+++ b/src/main/kotlin/com/whatever/global/security/exception/SecurityException.kt
@@ -1,0 +1,18 @@
+package com.whatever.global.security.exception
+
+import com.whatever.global.exception.common.CaramelException
+
+open class CaramelSecurityException(
+    errorCode: SecurityExceptionCode,
+    detailMessage: String? = null
+) : CaramelException(errorCode, detailMessage)
+
+class AccessDeniedException(
+    errorCode: SecurityExceptionCode,
+    detailMessage: String? = null
+) : CaramelSecurityException(errorCode)
+
+class AuthenticationException(
+    errorCode: SecurityExceptionCode,
+    detailMessage: String? = null
+) : CaramelSecurityException(errorCode)

--- a/src/main/kotlin/com/whatever/global/security/exception/SecurityExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/security/exception/SecurityExceptionCode.kt
@@ -1,0 +1,19 @@
+package com.whatever.global.security.exception
+
+import com.whatever.global.exception.common.CaramelExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class SecurityExceptionCode(
+    sequence: String,
+    override val message: String,
+    override val status: HttpStatus = HttpStatus.BAD_REQUEST,
+) : CaramelExceptionCode {
+
+    FORBIDDEN("000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED("001", "인증이 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    AUTHENTICATION_NOT_FOUND("002", "인증 정보가 없습니다.", HttpStatus.UNAUTHORIZED),
+    USER_NOT_FOUND("003", "사용자 정보가 존재하지 않습니다. 재가입이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    ;
+
+    override val code = "SECURITY$sequence"
+}

--- a/src/main/kotlin/com/whatever/global/security/exception/SecurityExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/security/exception/SecurityExceptionCode.kt
@@ -11,7 +11,7 @@ enum class SecurityExceptionCode(
 
     FORBIDDEN("000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
     UNAUTHORIZED("001", "인증이 실패했습니다.", HttpStatus.UNAUTHORIZED),
-    AUTHENTICATION_NOT_FOUND("002", "인증 정보가 없습니다.", HttpStatus.UNAUTHORIZED),
+    AUTHENTICATION_NOT_FOUND("002", "인증 정보가 없습니다. 재로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("003", "사용자 정보가 존재하지 않습니다. 재가입이 필요합니다.", HttpStatus.UNAUTHORIZED),
     ;
 

--- a/src/main/kotlin/com/whatever/global/security/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/whatever/global/security/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,70 @@
+package com.whatever.global.security.filter
+
+import com.whatever.domain.auth.service.JwtHelper
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.global.security.principal.CaramelUserDetails
+import com.whatever.global.security.exception.AuthenticationException
+import com.whatever.global.security.exception.SecurityExceptionCode
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(
+    private val jwtHelper: JwtHelper,
+    private val userRepository: UserRepository,
+) : OncePerRequestFilter() {
+
+    companion object {
+        private const val AUTH_JWT_HEADER = "Authorization"
+        private const val BEARER_TYPE = "Bearer "
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val accessToken = extractAccessToken(request)
+        if (accessToken != null) {
+            val context = SecurityContextHolder.createEmptyContext()
+            context.authentication = getAuthentication(accessToken)
+            SecurityContextHolder.setContext(context)
+        }
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun getAuthentication(accessToken: String): UsernamePasswordAuthenticationToken {
+        val userId = jwtHelper.parseAccessToken(accessToken)
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw AuthenticationException(
+                errorCode = SecurityExceptionCode.USER_NOT_FOUND,
+                detailMessage = "가입되지 않은 유저입니다. 재가입이 필요합니다. UserId: ${userId}"
+            )
+
+        val userDetails = CaramelUserDetails(
+            userId = user.id!!,
+            status = user.userStatus
+        )
+
+        return UsernamePasswordAuthenticationToken(
+            userDetails,
+            userDetails.password,
+            userDetails.authorities
+        )
+    }
+
+    private fun extractAccessToken(request: HttpServletRequest): String? {
+        val rawToken: String? = request.getHeader(AUTH_JWT_HEADER)
+        if (rawToken.isNullOrBlank() || !rawToken.startsWith(BEARER_TYPE)) {
+            return null
+        }
+        return rawToken.substring(BEARER_TYPE.length)
+    }
+}

--- a/src/main/kotlin/com/whatever/global/security/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/whatever/global/security/filter/JwtAuthenticationFilter.kt
@@ -40,13 +40,9 @@ class JwtAuthenticationFilter(
         filterChain.doFilter(request, response)
     }
 
-    private fun getAuthentication(accessToken: String): UsernamePasswordAuthenticationToken {
+    private fun getAuthentication(accessToken: String): UsernamePasswordAuthenticationToken? {
         val userId = jwtHelper.parseAccessToken(accessToken)
-        val user = userRepository.findByIdOrNull(userId)
-            ?: throw AuthenticationException(
-                errorCode = SecurityExceptionCode.USER_NOT_FOUND,
-                detailMessage = "가입되지 않은 유저입니다. 재가입이 필요합니다. UserId: ${userId}"
-            )
+        val user = userRepository.findByIdOrNull(userId) ?: return null
 
         val userDetails = CaramelUserDetails(
             userId = user.id!!,

--- a/src/main/kotlin/com/whatever/global/security/filter/JwtExceptionFilter.kt
+++ b/src/main/kotlin/com/whatever/global/security/filter/JwtExceptionFilter.kt
@@ -1,6 +1,7 @@
 package com.whatever.global.security.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.whatever.global.exception.GlobalExceptionCode
 import com.whatever.global.jwt.exception.CaramelJwtException
 import com.whatever.global.security.exception.AuthenticationException
 import com.whatever.global.security.util.setExceptionResponse
@@ -27,10 +28,10 @@ class JwtExceptionFilter(
                 detailMessage = e.detailMessage,
                 objectMapper = objectMapper
             )
-        } catch (e: AuthenticationException) {
+        } catch (e: Exception) {
             response.setExceptionResponse(
-                errorCode = e.errorCode,
-                detailMessage = e.detailMessage,
+                errorCode = GlobalExceptionCode.UNKNOWN,
+                detailMessage = "인증 과정에서 예상하지 못한 에러가 발생했습니다.",
                 objectMapper = objectMapper
             )
         }

--- a/src/main/kotlin/com/whatever/global/security/filter/JwtExceptionFilter.kt
+++ b/src/main/kotlin/com/whatever/global/security/filter/JwtExceptionFilter.kt
@@ -1,0 +1,38 @@
+package com.whatever.global.security.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.whatever.global.jwt.exception.CaramelJwtException
+import com.whatever.global.security.exception.AuthenticationException
+import com.whatever.global.security.util.setExceptionResponse
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtExceptionFilter(
+    private val objectMapper: ObjectMapper
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: CaramelJwtException) {
+            response.setExceptionResponse(
+                errorCode = e.errorCode,
+                detailMessage = e.detailMessage,
+                objectMapper = objectMapper
+            )
+        } catch (e: AuthenticationException) {
+            response.setExceptionResponse(
+                errorCode = e.errorCode,
+                detailMessage = e.detailMessage,
+                objectMapper = objectMapper
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/whatever/global/security/handler/CaramelAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/whatever/global/security/handler/CaramelAccessDeniedHandler.kt
@@ -1,0 +1,49 @@
+package com.whatever.global.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.whatever.domain.user.dto.UserStatus
+import com.whatever.global.security.exception.SecurityExceptionCode
+import com.whatever.global.security.util.getCurrentUserAuthorities
+import com.whatever.global.security.util.getCurrentUserId
+import com.whatever.global.security.util.setExceptionResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class CaramelAccessDeniedHandler(
+    private val objectMapper: ObjectMapper
+) : AccessDeniedHandler {
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+
+        val userAuthorities = getCurrentUserAuthorities()
+        logger.error(accessDeniedException) {
+            "API 접근 실패. UserId: ${getCurrentUserId()}, Authorities: ${userAuthorities}, API: ${request.requestURI}"
+        }
+
+        val detailMessage = when {
+            userAuthorities.hasAuthority(UserStatus.NEW) -> "신규 유저이므로 초기 정보를 입력해야합니다."
+            else -> "해당하는 API에 접근할 권한이 없습니다. 접근 API: ${request.requestURI}"
+        }
+
+        response.setExceptionResponse(
+            errorCode = SecurityExceptionCode.FORBIDDEN,
+            detailMessage = detailMessage,
+            objectMapper = objectMapper
+        )
+    }
+}
+
+private fun Set<GrantedAuthority>.hasAuthority(userStatus: UserStatus): Boolean {
+    return any { it.authority.endsWith(userStatus.name) }
+}

--- a/src/main/kotlin/com/whatever/global/security/handler/CaramelAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/whatever/global/security/handler/CaramelAuthenticationEntryPoint.kt
@@ -1,0 +1,31 @@
+package com.whatever.global.security.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.whatever.global.security.exception.SecurityExceptionCode
+import com.whatever.global.security.util.setExceptionResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class CaramelAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        logger.error(authException) { request.requestURI }
+        response.setExceptionResponse(
+            errorCode = SecurityExceptionCode.UNAUTHORIZED,
+            detailMessage = "인증에 실패했습니다. 접근 API: ${request.requestURI}",
+            objectMapper = objectMapper
+        )
+    }
+}

--- a/src/main/kotlin/com/whatever/global/security/principal/CaramelUserDetails.kt
+++ b/src/main/kotlin/com/whatever/global/security/principal/CaramelUserDetails.kt
@@ -1,0 +1,32 @@
+package com.whatever.global.security.principal
+
+import com.whatever.domain.user.dto.UserStatus
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class CaramelUserDetails(
+    private val userId: Long,
+    private val status: UserStatus,
+) : UserDetails {
+
+    private val userIdStr = userId.toString()
+
+    override fun getAuthorities(): Set<SimpleGrantedAuthority> {
+        return setOf(
+            SimpleGrantedAuthority("ROLE_${status.name}"),
+        )
+    }
+
+    override fun getPassword(): String? {
+        return null
+    }
+
+    override fun getUsername(): String {
+        return userIdStr
+    }
+
+    fun getUserId(): Long {
+        return userId
+    }
+
+}

--- a/src/main/kotlin/com/whatever/global/security/util/HttpServletResponseUtil.kt
+++ b/src/main/kotlin/com/whatever/global/security/util/HttpServletResponseUtil.kt
@@ -1,0 +1,28 @@
+package com.whatever.global.security.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.whatever.global.exception.common.CaramelExceptionCode
+import com.whatever.global.exception.dto.CaramelApiResponse
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+
+fun HttpServletResponse.setExceptionResponse(
+    errorCode: CaramelExceptionCode,
+    detailMessage: String? = null,
+    objectMapper: ObjectMapper,
+) {
+    characterEncoding = Charsets.UTF_8.name()
+    contentType = MediaType.APPLICATION_JSON_VALUE
+    status = errorCode.status.value()
+    writer.write(
+        objectMapper.writeValueAsString(
+            CaramelApiResponse.failed(
+                code = errorCode.code,
+                message = errorCode.message,
+                debugMessage = detailMessage
+            )
+        )
+    )
+    writer.flush()
+    writer.close()
+}

--- a/src/main/kotlin/com/whatever/global/security/util/SecurityUtil.kt
+++ b/src/main/kotlin/com/whatever/global/security/util/SecurityUtil.kt
@@ -1,0 +1,32 @@
+package com.whatever.global.security.util
+
+import com.whatever.global.security.principal.CaramelUserDetails
+import com.whatever.global.security.exception.AuthenticationException
+import com.whatever.global.security.exception.SecurityExceptionCode
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+
+fun getCurrentUserAuthorities(): Set<GrantedAuthority> {
+    return getUserDetails().authorities
+}
+
+fun getCurrentUserId(): Long {
+    return getUserDetails().getUserId()
+}
+
+fun getUserDetails(): CaramelUserDetails {
+    val authentication = getAuthentication()
+        .takeIf { it.isAuthenticated }
+        ?: throw AuthenticationException(
+            errorCode = SecurityExceptionCode.UNAUTHORIZED,
+            detailMessage = "인증 정보가 존재하지 않습니다. 재로그인이 필요합니다."
+        )
+
+    return authentication.principal as CaramelUserDetails
+}
+
+private fun getAuthentication(): Authentication {
+    return SecurityContextHolder.getContext().authentication
+        ?: throw AuthenticationException(SecurityExceptionCode.AUTHENTICATION_NOT_FOUND)
+}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -17,7 +17,7 @@ spring:
         use_sql_comments: true
         format_sql: true
         globally_quoted_identifiers: true
-        show_sql: true
+        show_sql: false
   cloud:
     openfeign:
       okhttp:

--- a/src/test/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProviderTest.kt
+++ b/src/test/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProviderTest.kt
@@ -1,0 +1,88 @@
+package com.whatever.domain.auth.service.provider
+
+import com.whatever.domain.auth.client.KakaoOAuthClient
+import com.whatever.domain.auth.client.dto.KakaoAccount
+import com.whatever.domain.auth.client.dto.KakaoUserInfoResponse
+import com.whatever.domain.auth.client.dto.Profile
+import com.whatever.domain.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@ActiveProfiles("test")
+@SpringBootTest
+class KakaoUserProviderTest @Autowired constructor(
+    private val kakaoUserProvider: KakaoUserProvider,
+    private val userRepository: UserRepository
+) {
+
+    @MockitoBean
+    private lateinit var kakaoOAuthClient: KakaoOAuthClient
+
+    @BeforeEach
+    fun cleanDatabase() {
+        userRepository.deleteAllInBatch()
+    }
+
+    @Test
+    fun findOrCreateUserWithMultiThread() {
+        Mockito.`when`(kakaoOAuthClient.getUserInfo(Mockito.anyString()))
+            .thenReturn(
+                KakaoUserInfoResponse(
+                    id = 1L,
+                    KakaoAccount(
+                        Profile(
+                            nickname = "caramel",
+                            thumbnailImageUrl = "http://test.test.test/thumbnailImageUrl",
+                            profileImageUrl = "http://test.test.test/profileImageUrl",
+                        )
+                    )
+                )
+            )
+
+        // given
+        val kakaoAccessToken = "test-kakao-access-token"
+
+        val threadCount = 1000
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+
+        val successCnt = AtomicInteger()
+        val failCnt = AtomicInteger()
+
+        // when
+        repeat(threadCount) {
+            executor.submit {
+                try {
+                    kakaoUserProvider.findOrCreateUser(kakaoAccessToken)
+                    successCnt.incrementAndGet()
+                } catch (e: Exception) {
+                    failCnt.incrementAndGet()
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        latch.await(10, TimeUnit.SECONDS).let {
+            executor.shutdown()
+        }
+
+        // then
+        userRepository.findAll().let {
+            assertThat(it.size).isEqualTo(1)
+        }
+
+        assertThat(successCnt.toInt()).isEqualTo(threadCount)
+        assertThat(failCnt.toInt()).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #21 

## 작업한 내용
- SpringSecurity 추가
- Jwt 인증 필터 추가
- 로그인 추가 & 회원가입 로직과 병합

## PR 포인트
- 플랫폼별로 회원가입에 대한 로직을 전략패턴으로 분리하려고 해봤습니다