### PR TITLE
[Feat] RedisUtil 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.4.0"
 }
 
 kotlin {

--- a/src/main/kotlin/com/whatever/util/RedisUtil.kt
+++ b/src/main/kotlin/com/whatever/util/RedisUtil.kt
@@ -1,0 +1,47 @@
+package com.whatever.util
+
+import com.whatever.config.properties.JwtProperties
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RedisUtil(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val jwtProperties: JwtProperties,
+) {
+
+    companion object {
+        private const val REFRESH_TOKEN_KEY = "refresh_token"
+    }
+
+    fun saveRefreshToken(
+        userId: Long,
+        deviceId: String,
+        refreshToken: String,
+        ttlSeconds: Long = jwtProperties.refreshExpirationSec,
+    ) {
+        redisTemplate.opsForValue().set(
+            "${REFRESH_TOKEN_KEY}:${userId}:${deviceId}",
+            refreshToken,
+            ttlSeconds,
+            TimeUnit.SECONDS,
+        )
+    }
+
+    fun getRefreshToken(
+        userId: Long,
+        deviceId: String,
+    ): String? {
+        val key = "${REFRESH_TOKEN_KEY}:${userId}:${deviceId}"
+        return redisTemplate.opsForValue().get(key)
+    }
+
+    fun deleteRefreshToken(
+        userId: Long,
+        deviceId: String,
+    ): Boolean {
+        val key = "${REFRESH_TOKEN_KEY}:${userId}:${deviceId}"
+        return redisTemplate.delete(key)
+    }
+}

--- a/src/test/kotlin/com/whatever/util/RedisUtilTest.kt
+++ b/src/test/kotlin/com/whatever/util/RedisUtilTest.kt
@@ -1,0 +1,116 @@
+package com.whatever.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+class RedisUtilTest @Autowired constructor(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val redisUtil: RedisUtil,
+) {
+
+    @BeforeEach
+    fun setUp() {
+        val connectionFactory = redisTemplate.connectionFactory
+        check(connectionFactory != null)
+        connectionFactory.connection.serverCommands().flushAll()
+    }
+
+    @Test
+    @DisplayName("refresh token을 저장한다.")
+    fun saveRefreshToken() {
+        // given
+        val userId = 1L
+        val deviceId = "test-device"
+        val expectedKey = "refresh_token:${userId}:${deviceId}"
+        val refreshToken = "test.refresh.token"
+
+        // when
+        redisUtil.saveRefreshToken(userId, deviceId, refreshToken)
+
+        // then
+        val savedToken = redisTemplate.opsForValue().get(expectedKey)
+        assertThat(savedToken).isEqualTo(refreshToken)
+    }
+
+    @Test
+    @DisplayName("같은 key로 토큰 재저장 시 기존 토큰을 대체한다.")
+    fun saveRefreshToken_OverrideExistingToken() {
+        // given
+        val userId = 1L
+        val deviceId = "test-device"
+        val expectedKey = "refresh_token:${userId}:${deviceId}"
+
+        val oldRefreshToken = "test.refresh.oldToken"
+        val newRefreshToken = "test.refresh.newToken"
+        redisUtil.saveRefreshToken(userId, deviceId, oldRefreshToken)
+
+        // when
+        redisUtil.saveRefreshToken(userId, deviceId, newRefreshToken)
+
+        // then
+        val savedToken = redisTemplate.opsForValue().get(expectedKey)
+        assertThat(savedToken).isEqualTo(newRefreshToken)
+    }
+
+    @Test
+    @DisplayName("저장된 토큰을 조회한다")
+    fun getRefreshToken() {
+        // given
+        val userId = 1L
+        val deviceId = "test-device"
+        val refreshToken = "test.refresh.token"
+        redisUtil.saveRefreshToken(userId, deviceId, refreshToken)
+
+        // when
+        val savedToken = redisUtil.getRefreshToken(userId, deviceId)
+
+        // then
+        assertThat(savedToken).isEqualTo(refreshToken)
+    }
+
+    @DisplayName("만료된 토큰을 조회하면 null을 반환한다.")
+    @Test
+    fun getRefreshToken_WithExpiredToken() {
+        // given
+        val userId = 1L
+        val deviceId = "test-device"
+        val refreshToken = "test.refresh.token"
+        val ttlSeconds = 1L
+        redisUtil.saveRefreshToken(userId, deviceId, refreshToken, ttlSeconds)
+
+        // when
+        Thread.sleep(Duration.ofMillis(1200))
+        val retrievedToken = redisUtil.getRefreshToken(userId, deviceId)
+
+        // then
+        assertThat(retrievedToken).isNull()
+    }
+
+    @DisplayName("토큰이 삭제되면 null을 반환한다.")
+    @Test
+    fun deleteRefreshToken() {
+        // given
+        val userId = 1L
+        val deviceId = "test-device"
+        val refreshToken = "test.refresh.token"
+        val ttlSeconds = 1L
+        redisUtil.saveRefreshToken(userId, deviceId, refreshToken, ttlSeconds)
+
+        // when
+        redisUtil.deleteRefreshToken(userId, deviceId)
+
+        // then
+        val savedToken = redisUtil.getRefreshToken(userId, deviceId)
+        assertThat(savedToken).isNull()
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #23 

## 작업한 내용
- refreshToken 저장, 조회, 삭제 로직이 있는 RedisUtil 추가
- AuthService.createTokenAndSave()의 refreshToken 저장 코드 변경

## PR 포인트
- 생각해보니 저희가 멀티플랫폼이어서 한 유저에 다수의 refresh token이 저장되어야 할것 같았습니다.
- 따라서 로그인/회원가입 요청이나, 토큰 재발급 요청 시 client의 device 종류(혹은 device 고유의 id)도 함께 수신해야 할것 같습니다.
- 코드에는 deviceId를 반영해두었고 임시 문자열로 채워두었습니다.