### PR TITLE
[Feat] Apple OIDC 추가

### DIFF
--- a/src/main/kotlin/com/whatever/config/properties/OauthProperties.kt
+++ b/src/main/kotlin/com/whatever/config/properties/OauthProperties.kt
@@ -4,10 +4,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("oauth")
 data class OauthProperties (
-    val kakao: OauthSecret
+    val kakao: KakaoOauthSecret,
+    val apple: AppleOauthSecret,
 )
 
-data class OauthSecret(
+data class KakaoOauthSecret(
     val baseUrl: String,
     val clientId: String,
     val clientSecret: String,
@@ -18,3 +19,12 @@ data class OauthSecret(
     val adminKeyWithPrefix
         get() = "KakaoAK ${adminKey}"
 }
+
+data class AppleOauthSecret(
+    val baseUrl: String,
+    val teamId: String,
+    val serviceId: String,
+    val keyId: String,
+    val keyPath: String,
+    val redirectUrl: String,
+)

--- a/src/main/kotlin/com/whatever/domain/auth/client/AppleFeignClient.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/client/AppleFeignClient.kt
@@ -1,0 +1,25 @@
+package com.whatever.domain.auth.client
+
+import com.whatever.domain.auth.client.dto.OIDCPublicKeysResponse
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+
+@FeignClient(
+    name = "AppleOIDCClient",
+    url = "https://appleid.apple.com",
+)
+interface AppleOIDCClient {
+
+    @Cacheable(
+        cacheNames = ["apple-oidc"],
+        cacheManager = "oidcCacheManager"
+    )
+    @GetMapping(
+        path = ["/auth/keys"],
+        consumes = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getOIDCPublicKey(): OIDCPublicKeysResponse
+
+}

--- a/src/main/kotlin/com/whatever/domain/auth/client/KakaoFeignClient.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/client/KakaoFeignClient.kt
@@ -54,9 +54,8 @@ interface KakaoOIDCClient {
     )
     @GetMapping(
         path = ["/.well-known/jwks.json"],
-        consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE]
     )
-    fun getOIDCPublicKey(): KakaoOIDCPublicKeysResponse
+    fun getOIDCPublicKey(): OIDCPublicKeysResponse
 
     /**
      * 토큰의 유효성 검증이 불가능하므로 디버깅 용도로만 사용해야 한다.

--- a/src/main/kotlin/com/whatever/domain/auth/client/dto/AppleIdTokenDto.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/client/dto/AppleIdTokenDto.kt
@@ -1,0 +1,19 @@
+package com.whatever.domain.auth.client.dto
+
+data class AppleIdTokenPayload(
+    val iss: String,
+    val aud: String,
+    val exp: Long,
+    val iat: Long,
+    val sub: String,
+    val cHash: String,
+    val email: String? = null,
+    val emailVerified: Boolean,
+    val isPrivateEmail: Boolean,
+    val authTime: Long,
+    val nonceSupported: Boolean,
+    val nonce: String? = null,
+) {
+    val platformUserId
+        get() = sub
+}

--- a/src/main/kotlin/com/whatever/domain/auth/client/dto/OIDCPublicKeysDto.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/client/dto/OIDCPublicKeysDto.kt
@@ -2,7 +2,7 @@ package com.whatever.domain.auth.client.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
-data class KakaoOIDCPublicKeysResponse(
+data class OIDCPublicKeysResponse(
     val keys: List<JsonWebKey> = emptyList()
 )
 

--- a/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
@@ -1,14 +1,15 @@
 package com.whatever.domain.auth.controller
 
+import com.whatever.domain.auth.dto.SignupSigninRequest
 import com.whatever.domain.auth.dto.SocialAuthResponse
 import com.whatever.domain.auth.service.AuthService
-import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController
     description = "인증 API"
 )
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/v1/auth")
 class AuthController(
     private val authService: AuthService,
 ) {
@@ -31,10 +32,12 @@ class AuthController(
     )
     @PostMapping("/sign-up")
     fun signUp(
-        loginPlatform: LoginPlatform,
-        accessToken: String,
+        @RequestBody request: SignupSigninRequest,
     ): CaramelApiResponse<SocialAuthResponse> {
-        val socialAuthResponse = authService.signUpOrSignIn(loginPlatform, accessToken)
+        val socialAuthResponse = authService.signUpOrSignIn(
+            loginPlatform = request.loginPlatform,
+            accessToken = request.accessToken
+        )
         return socialAuthResponse.succeed()
     }
 }

--- a/src/main/kotlin/com/whatever/domain/auth/dto/AppleAuthFormData.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/dto/AppleAuthFormData.kt
@@ -1,0 +1,36 @@
+package com.whatever.domain.auth.dto
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+
+class AppleAuthFormData(
+    val code: String,
+    id_token: String,  // apple에서 formdata 전송 시 snake-case를 사용
+    val state: String? = null,
+    private val user: String? = null
+) {
+    val idToken = id_token
+
+    val appleUser: AppleUser?
+        get() {
+            return user?.let { jacksonObjectMapper().readValue(user, AppleUser::class.java) }
+        }
+
+    override fun toString(): String {
+        val className = this::class.simpleName
+        return "${className}(code=${code}, idToken=${idToken}, state=${state}, appleUser=${appleUser})"
+    }
+}
+
+data class AppleUser(
+    val email: String? = null,
+    val name: AppleUserName? = null
+)
+
+data class AppleUserName(
+    val firstName: String,
+    val lastName: String,
+) {
+    override fun toString(): String {
+        return "${lastName}${firstName}"
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/auth/dto/SignupSigninRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/dto/SignupSigninRequest.kt
@@ -1,0 +1,8 @@
+package com.whatever.domain.auth.dto
+
+import com.whatever.domain.user.model.LoginPlatform
+
+data class SignupSigninRequest(
+    val loginPlatform: LoginPlatform,
+    val accessToken: String,
+)

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/AppleUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/AppleUserProvider.kt
@@ -1,11 +1,22 @@
 package com.whatever.domain.auth.service.provider
 
+import com.whatever.domain.auth.client.AppleOIDCClient
+import com.whatever.domain.auth.client.dto.AppleIdTokenPayload
+import com.whatever.domain.auth.dto.AppleAuthFormData
+import com.whatever.domain.auth.dto.AppleUserName
+import com.whatever.domain.auth.service.OIDCHelper
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
+import com.whatever.domain.user.repository.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Component
 
 @Component
-class AppleUserProvider : SocialUserProvider {
+class AppleUserProvider(
+    private val appleOIDCClient: AppleOIDCClient,
+    private val oidcHelper: OIDCHelper,
+    private val userRepository: UserRepository,
+) : SocialUserProvider {
 
     override val platform: LoginPlatform
         get() = LoginPlatform.APPLE
@@ -14,4 +25,34 @@ class AppleUserProvider : SocialUserProvider {
         // TODO(준용): Apple 유저
         throw IllegalStateException("미구현된 기능합니다.")
     }
+
+    fun findOrCreateUserByAppleAuthFormData(appleAuthFormData: AppleAuthFormData): User {
+        return findOrCreateUserByIdToken(
+            socialIdToken = appleAuthFormData.idToken,
+            userName = appleAuthFormData.appleUser?.name
+        )
+    }
+
+    fun findOrCreateUserByIdToken(socialIdToken: String, userName: AppleUserName? = null): User {
+        val keys = appleOIDCClient.getOIDCPublicKey().keys
+
+        val payload = oidcHelper.parseAppleIdToken(socialIdToken, keys)
+
+        userRepository.findByPlatformUserId(payload.platformUserId)?.let {
+            return it
+        }
+
+        return try {
+            userRepository.save(payload.toUser(userName))
+        } catch (e: DataIntegrityViolationException) {
+            userRepository.findByPlatformUserId(payload.platformUserId) ?: throw e
+        }
+    }
 }
+
+private fun AppleIdTokenPayload.toUser(userName: AppleUserName? = null) = User(
+    platform = LoginPlatform.APPLE,
+    platformUserId = sub,
+    email = email,
+    nickname = userName?.toString()
+)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,13 @@ oauth:
     redirect-url: ${OAUTH_REDIRECT_URL}
     app-id: ${OAUTH_APP_ID}
     admin-key: ${OAUTH_ADMIN_KEY}
+  apple:
+    base-url: ${APPLE_BASE_URL}
+    team-id: ${APPLE_TEAM_ID}
+    service-id: ${APPLE_SERVICE_ID}
+    key-id: ${APPLE_KEY_ID}
+    key-path: ${APPLE_KEY_PATH}
+    redirect-url: ${APPLE_REDIRECT_URI}
 springdoc:
   default-produces-media-type: application/json
   default-consumes-media-type: application/json


### PR DESCRIPTION
## 관련 이슈
- close #29 

## 작업한 내용
- Apple OIDC 를 통한 UserProvider 구현

## PR 포인트
- 기존 코드에는 accessToken을 사용한 로그인/회원가입만 존재합니다. 추후 id token을 사용하여 로그인 가능하도록 수정해야합니다.
- AuthController의 기본 endpoint 경로에 "/v1"을 추가했습니다. 앞으로 도메인별로 endpoint를 추가할 때 이와 같이 반영해주세요~
- 기존 AuthController.signUp() 메서드에 @RequestBody가 없어 동작하지 않아 수정했습니다.