### PR TITLE
[Feat] Spring Security config 추가 및 수정

### DIFF
--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.whatever.config
 import com.whatever.domain.user.dto.UserStatus
 import com.whatever.global.security.filter.JwtAuthenticationFilter
 import com.whatever.global.security.filter.JwtExceptionFilter
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
@@ -88,6 +89,20 @@ class SecurityConfig(
         val expressionHandler = DefaultMethodSecurityExpressionHandler()
         expressionHandler.setRoleHierarchy(roleHierarchy())
         return expressionHandler
+    }
+
+    @Bean
+    fun jwtAuthenticationFilterRegistration(filter: JwtAuthenticationFilter): FilterRegistrationBean<JwtAuthenticationFilter> {
+        val registration: FilterRegistrationBean<JwtAuthenticationFilter> = FilterRegistrationBean<JwtAuthenticationFilter>(filter)
+        registration.isEnabled = false
+        return registration
+    }
+
+    @Bean
+    fun jwtExceptionFilterRegistration(filter: JwtExceptionFilter): FilterRegistrationBean<JwtExceptionFilter> {
+        val registration: FilterRegistrationBean<JwtExceptionFilter> = FilterRegistrationBean<JwtExceptionFilter>(filter)
+        registration.isEnabled = false
+        return registration
     }
 
 }

--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -18,7 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
+import org.springframework.security.web.authentication.logout.LogoutFilter
 
 @EnableMethodSecurity
 @EnableWebSecurity
@@ -49,8 +49,8 @@ class SecurityConfig(
         }
 
         http.invoke {
-            addFilterBefore<BasicAuthenticationFilter>(jwtAuthenticationFilter)
-            addFilterBefore<JwtAuthenticationFilter>(jwtExceptionFilter)
+            addFilterAfter<LogoutFilter>(jwtExceptionFilter)
+            addFilterAfter<JwtExceptionFilter>(jwtAuthenticationFilter)
         }
 
         http.invoke {


### PR DESCRIPTION
## 관련 이슈
- close #38 

## 작업한 내용
- Custom Filter의 중복 등록 방지
- Custom Filter 위치 조정

## PR 포인트
- Spring Security Docs에 authentication filter를 LogoutFilter 다음에 두는것을 권장한다고 나와있어 수정했습니다.
- DI 때문에 Filter를 Bean으로 정의했는데, 스프링 컨테이너에 중복으로 등록되고있어 config에 관련 메서드를 추가했습니다.