### PR TITLE
[Feat] KakaoLogin, AppleLogin OIDC 방식으로 동작하도록 수정

### DIFF
--- a/src/main/kotlin/com/whatever/domain/auth/client/dto/KakaoIdTokenDto.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/client/dto/KakaoIdTokenDto.kt
@@ -21,4 +21,6 @@ data class KakaoIdTokenPayload(
     val nickname: String? = null,
     val picture: String? = null,
     val email: String? = null
-)
+) {
+    val platformUserId get() = sub
+}

--- a/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
@@ -37,7 +37,7 @@ class AuthController(
     ): CaramelApiResponse<SignInResponse> {
         val socialAuthResponse = authService.signUpOrSignIn(
             loginPlatform = request.loginPlatform,
-            accessToken = request.idToken
+            idToken = request.idToken
         )
         return socialAuthResponse.succeed()
     }

--- a/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
@@ -22,7 +22,7 @@ class AuthService(
 
     fun signUpOrSignIn(
         loginPlatform: LoginPlatform,
-        accessToken: String,
+        idToken: String,
     ): SignInResponse {
         val userProvider = userProviderMap[loginPlatform]
             ?: throw GlobalException(
@@ -30,7 +30,7 @@ class AuthService(
                 detailMessage = "일치하는 로그인 플랫폼이 없습니다. platform: $loginPlatform"
             )
 
-        val user = userProvider.findOrCreateUser(accessToken)
+        val user = userProvider.findOrCreateUser(idToken)
         val userId = user.id ?: throw GlobalException(GlobalExceptionCode.ARGS_VALIDATION_FAILED)
 
         val serviceToken = createTokenAndSave(userId = userId)

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProvider.kt
@@ -1,49 +1,46 @@
 package com.whatever.domain.auth.service.provider
 
-import com.whatever.domain.auth.client.KakaoOAuthClient
-import com.whatever.domain.auth.client.dto.KakaoUserInfoResponse
+import com.whatever.domain.auth.client.KakaoOIDCClient
+import com.whatever.domain.auth.client.dto.KakaoIdTokenPayload
+import com.whatever.domain.auth.service.OIDCHelper
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
 import com.whatever.domain.user.repository.UserRepository
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Component
-import java.time.LocalDate
 
 @Component
 class KakaoUserProvider(
-    private val kakaoOAuthClient: KakaoOAuthClient,
+    private val kakaoOIDCClient: KakaoOIDCClient,
     private val userRepository: UserRepository,
+    private val oidcHelper: OIDCHelper,
 ) : SocialUserProvider {
 
     override val platform: LoginPlatform
         get() = LoginPlatform.KAKAO
 
-    override fun findOrCreateUser(socialAccessToken: String): User {
-        val userInfo = kakaoOAuthClient.getUserInfo(socialAccessToken)
-        userRepository.findByPlatformUserId(userInfo.platformUserId)?.let {
+    override fun findOrCreateUser(socialIdToken: String): User {
+        val kakaoPublicKey = kakaoOIDCClient.getOIDCPublicKey()
+        val idTokenPayload = oidcHelper.parseKakaoIdToken(
+            idToken = socialIdToken,
+            oidcPublicKeys = kakaoPublicKey.keys,
+        )
+
+        userRepository.findByPlatformUserId(idTokenPayload.platformUserId)?.let {
             return it
         }
 
         return try {
-            userRepository.save(userInfo.toUser())
+            userRepository.save(idTokenPayload.toUser())
         } catch (e: DataIntegrityViolationException) {
-            userRepository.findByPlatformUserId(userInfo.platformUserId) ?: throw e
+            userRepository.findByPlatformUserId(idTokenPayload.platformUserId) ?: throw e
         }
     }
 }
 
-private fun KakaoUserInfoResponse.toUser() = User(
+private fun KakaoIdTokenPayload.toUser() = User(
     platform = LoginPlatform.KAKAO,
     platformUserId = platformUserId,
-    nickname = kakaoAccount.profile.nickname,
-    email = kakaoAccount.email,
-    birthDate = if (kakaoAccount.birthYear != null && kakaoAccount.birthDay != null) {
-        LocalDate.of(
-            kakaoAccount.birthYear.toInt(),
-            kakaoAccount.birthDay.take(2).toInt(),
-            kakaoAccount.birthDay.takeLast(2).toInt()
-        )
-    } else {
-        null
-    }
+    nickname = nickname,
+    email = email,
 )

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/SocialUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/SocialUserProvider.kt
@@ -9,5 +9,5 @@ interface SocialUserProvider {
     /**
      * 각 플랫폼의 AccessToken을 사용하여 가입된 User를 찾거나, 새로운 User를 저장하여 반환합니다.
      */
-    fun findOrCreateUser(socialAccessToken: String): User
+    fun findOrCreateUser(socialIdToken: String): User
 }

--- a/src/main/kotlin/com/whatever/global/exception/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/com/whatever/global/exception/GlobalControllerAdvice.kt
@@ -23,9 +23,9 @@ private val logger = KotlinLogging.logger {  }
 class GlobalControllerAdvice : CaramelControllerAdvice() {
 
     // TODO: 로깅처리 필수
-
     @ExceptionHandler(CaramelException::class)
     fun handleCaramelException(e: CaramelException): ResponseEntity<CaramelApiResponse<*>> {
+        logger.error(e) { "예상하지 못한 예외가 발생했습니다." }
         return createExceptionResponse(errorCode = e.errorCode, debugMessage = e.detailMessage)
     }
 


### PR DESCRIPTION
## 관련 이슈
- #41 

## 작업한 내용
- KakaoLogin accesstoken -> idToken 사용하도록 변경
- @given-dragon 만들어놓은 applelogin component 조합하여 애플로그인 IdToken으로 동작하도록 수정