### PR TITLE
[Feat] 컨텐츠 생성 - 메모

### DIFF
--- a/src/main/kotlin/com/whatever/domain/content/controller/ContentController.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/ContentController.kt
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.*
     description = "콘텐츠 API"
 )
 @RestController
-@RequestMapping("/v1/contents")
+@RequestMapping("/v1/content")
 class ContentController(
     private val contentService: ContentService,
 ) {

--- a/src/main/kotlin/com/whatever/domain/content/controller/ContentController.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/ContentController.kt
@@ -7,12 +7,16 @@ import com.whatever.domain.content.controller.dto.response.ContentDetailListResp
 import com.whatever.domain.content.controller.dto.response.ContentDetailResponse
 import com.whatever.domain.content.controller.dto.response.ContentSummaryResponse
 import com.whatever.domain.content.controller.dto.response.TagDto
+import com.whatever.domain.content.exception.ContentException
+import com.whatever.domain.content.exception.ContentExceptionCode
 import com.whatever.domain.content.model.ContentType
+import com.whatever.domain.content.service.ContentService
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
 import com.whatever.util.DateTimeUtil
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.*
 
@@ -22,7 +26,9 @@ import org.springframework.web.bind.annotation.*
 )
 @RestController
 @RequestMapping("/v1/contents")
-class ContentController {
+class ContentController(
+    private val contentService: ContentService,
+) {
 
     @Operation(
         summary = "더미 콘텐츠 조회",
@@ -52,18 +58,17 @@ class ContentController {
     }
 
     @Operation(
-        summary = "더미 콘텐츠 생성",
+        summary = "콘텐츠 생성",
         description = "콘텐츠를 생성합니다. 날짜 정보를 보내지 않으면 Memo, 날짜 정보가 포함되면 Schedule로 생성됩니다."
     )
     @PostMapping
-    fun createContent(@RequestBody request: CreateContentRequest): CaramelApiResponse<ContentSummaryResponse> {
-
-        // TODO(준용): 구현 필요
-        return ContentSummaryResponse(
-            contentId = 1L,
-            contentType = request.dateTimeInfo?.let { ContentType.SCHEDULE }
-                ?: ContentType.MEMO,
-        ).succeed()
+    fun createContent(
+        @Valid @RequestBody request: CreateContentRequest
+    ): CaramelApiResponse<ContentSummaryResponse> {
+        if (request.title.isNullOrBlank() && request.description.isNullOrBlank()) {
+            throw ContentException(errorCode = ContentExceptionCode.TITLE_OR_DESCRIPTION_REQUIRED)
+        }
+        return contentService.createContent(request).succeed()
     }
 
     @Operation(

--- a/src/main/kotlin/com/whatever/domain/content/controller/dto/request/CreateContentRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/dto/request/CreateContentRequest.kt
@@ -19,13 +19,6 @@ data class CreateContentRequest(
     val description: String? = null,
 
     @Schema(
-        description = "희망일",
-        example = "2025-02-16",
-        requiredMode = NOT_REQUIRED,
-    )
-    val wishDate: LocalDate? = null,
-
-    @Schema(
         description = "완료 여부",
         requiredMode = NOT_REQUIRED,
     )

--- a/src/main/kotlin/com/whatever/domain/content/controller/dto/request/CreateContentRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/dto/request/CreateContentRequest.kt
@@ -1,16 +1,21 @@
 package com.whatever.domain.content.controller.dto.request
 
+import com.whatever.domain.content.model.ContentDetail.Companion.MAX_DESCRIPTION_LENGTH
+import com.whatever.domain.content.model.ContentDetail.Companion.MAX_TITLE_LENGTH
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "콘텐츠 생성 요청 모델")
 data class CreateContentRequest(
     @Schema(description = "콘텐츠 제목. title, description 둘 중 하나는 필수입니다.", example = "맛집 리스트")
+    @field:Size(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
     val title: String? = null,
 
     @Schema(description = "콘텐츠 설명. title, description 둘 중 하나는 필수입니다.", example = "어제 함께 갔던 맛집들")
+    @field:Size(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
     val description: String? = null,
 
     @Schema(
@@ -30,7 +35,7 @@ data class CreateContentRequest(
         description = "태그 번호 리스트",
         requiredMode = NOT_REQUIRED,
     )
-    val tagList: List<TagIdDto> = emptyList(),
+    val tags: List<TagIdDto> = emptyList(),
 
     @Schema(
         description = "일정 정보 (캘린더 추가시에만 사용)",

--- a/src/main/kotlin/com/whatever/domain/content/exception/ContentException.kt
+++ b/src/main/kotlin/com/whatever/domain/content/exception/ContentException.kt
@@ -1,0 +1,8 @@
+package com.whatever.domain.content.exception
+
+import com.whatever.global.exception.common.CaramelException
+
+open class ContentException(
+    errorCode: ContentExceptionCode,
+    detailMessage: String? = null
+) : CaramelException(errorCode, detailMessage)

--- a/src/main/kotlin/com/whatever/domain/content/exception/ContentExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/content/exception/ContentExceptionCode.kt
@@ -1,0 +1,15 @@
+package com.whatever.domain.content.exception
+
+import com.whatever.global.exception.common.CaramelExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class ContentExceptionCode(
+    sequence: String,
+    override val message: String,
+    override val status: HttpStatus = HttpStatus.BAD_REQUEST,
+) : CaramelExceptionCode {
+
+    TITLE_OR_DESCRIPTION_REQUIRED("001", "title 또는 description 중 하나는 필수입니다.");
+
+    override val code = "Content$sequence"
+}

--- a/src/main/kotlin/com/whatever/domain/content/model/ContentDetail.kt
+++ b/src/main/kotlin/com/whatever/domain/content/model/ContentDetail.kt
@@ -12,4 +12,9 @@ class ContentDetail(
 
     @Column(nullable = false)
     var isCompleted: Boolean = false,
-)
+){
+    companion object {
+        const val MAX_TITLE_LENGTH = 30
+        const val MAX_DESCRIPTION_LENGTH = 5000
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/content/service/ContentService.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/ContentService.kt
@@ -1,0 +1,34 @@
+package com.whatever.domain.content.service
+
+import com.whatever.domain.content.controller.dto.request.CreateContentRequest
+import com.whatever.domain.content.controller.dto.response.ContentSummaryResponse
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.model.ContentType
+import org.springframework.stereotype.Component
+
+@Component
+class ContentService(
+    private val memoCreator: MemoCreator,
+) {
+    fun createContent(contentRequest: CreateContentRequest): ContentSummaryResponse {
+        return if (contentRequest.dateTimeInfo == null) {
+            memoCreator.createMemo(
+                title = contentRequest.title,
+                description = contentRequest.description,
+                isCompleted = contentRequest.isCompleted,
+                tagIds = contentRequest.tags.map { it.tagId },
+            ).toContentSummaryResponse()
+        } else {
+            // TODO(evergreentree97) : need schedule creator
+            ContentSummaryResponse(
+                contentId = 1L,
+                contentType = ContentType.SCHEDULE,
+            )
+        }
+    }
+}
+
+private fun Content.toContentSummaryResponse() = ContentSummaryResponse(
+    contentId = id!!,
+    contentType = type
+)

--- a/src/main/kotlin/com/whatever/domain/content/service/MemoCreator.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/MemoCreator.kt
@@ -1,0 +1,65 @@
+package com.whatever.domain.content.service
+
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.model.ContentDetail
+import com.whatever.domain.content.model.ContentType
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.content.tag.model.TagContentMapping
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import com.whatever.domain.content.tag.repository.TagRepository
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.global.security.util.SecurityUtil.getCurrentUserId
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class MemoCreator(
+    private val contentRepository: ContentRepository,
+    private val tagContentMappingRepository: TagContentMappingRepository,
+    private val userRepository: UserRepository,
+    private val tagRepository: TagRepository
+) {
+    @Transactional
+    fun createMemo(
+        title: String?,
+        description: String?,
+        isCompleted: Boolean,
+        tagIds: List<Long>,
+    ): Content {
+        val replacedTitle = when {
+            title.isNullOrBlank() && !description.isNullOrBlank() -> description.take(30)
+            else -> title!!
+        }
+        val contentDetail = ContentDetail(
+            title = replacedTitle,
+            description = description,
+            isCompleted = isCompleted
+        )
+
+        val userId = getCurrentUserId()
+        val user = userRepository.findByIdOrNull(userId)
+        val content = Content(
+            user = user!!,
+            contentDetail = contentDetail,
+            wishDate = null,
+            type = ContentType.MEMO
+        )
+
+        val savedContent = contentRepository.save(content)
+
+        if (tagIds.isNotEmpty()) {
+            val tags = tagRepository.findByIdIn(tagIds)
+            val mappings = tags.map { tag ->
+                TagContentMapping(
+                    tag = tag,
+                    content = savedContent
+                )
+            }
+
+            tagContentMappingRepository.saveAll(mappings)
+        }
+
+        return content
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/content/tag/repository/TagRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/repository/TagRepository.kt
@@ -4,4 +4,5 @@ import com.whatever.domain.content.tag.model.Tag
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TagRepository : JpaRepository<Tag, Long> {
+    fun findByIdIn(ids: List<Long>): List<Tag>
 }

--- a/src/test/kotlin/com/whatever/domain/ControllerTestSupport.kt
+++ b/src/test/kotlin/com/whatever/domain/ControllerTestSupport.kt
@@ -1,6 +1,8 @@
 package com.whatever.domain
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.whatever.domain.content.controller.ContentController
+import com.whatever.domain.content.service.ContentService
 import com.whatever.domain.user.controller.UserController
 import com.whatever.domain.user.service.UserService
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,7 +19,8 @@ import org.springframework.web.filter.OncePerRequestFilter
  */
 @WebMvcTest(
     controllers = [
-        UserController::class
+        UserController::class,
+        ContentController::class,
     ],
     excludeAutoConfiguration = [
         SecurityAutoConfiguration::class
@@ -36,4 +39,7 @@ abstract class ControllerTestSupport {
 
     @MockitoBean
     protected lateinit var userService: UserService
+
+    @MockitoBean
+    protected lateinit var contentService: ContentService
 }

--- a/src/test/kotlin/com/whatever/domain/content/controller/ContentControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/content/controller/ContentControllerTest.kt
@@ -1,0 +1,92 @@
+package com.whatever.domain.content.controller
+
+import com.whatever.domain.ControllerTestSupport
+import com.whatever.domain.content.controller.dto.request.CreateContentRequest
+import com.whatever.domain.content.controller.dto.request.DateTimeInfoDto
+import com.whatever.domain.content.controller.dto.request.TagIdDto
+import com.whatever.domain.content.exception.ContentExceptionCode
+import com.whatever.util.DateTimeUtil
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.post
+
+class ContentControllerTest : ControllerTestSupport() {
+
+    @DisplayName("콘텐츠를 생성한다. (Memo 타입)")
+    @Test
+    fun createContent_Memo() {
+        // given
+        val request = CreateContentRequest(
+            title = "메모 제목",
+            description = "메모 설명",
+            tags = listOf(TagIdDto(tagId = 1L)),
+            dateTimeInfo = null
+        )
+
+        // when // then
+        mockMvc.post("/v1/content") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @DisplayName("콘텐츠를 생성한다. (Schedule 타입)")
+    @Test
+    fun createContent_Schedule() {
+        // given
+        val request = CreateContentRequest(
+            title = "일정 제목",
+            description = "일정 설명",
+            tags = listOf(TagIdDto(tagId = 1L)),
+            dateTimeInfo = DateTimeInfoDto(
+                startDateTime = DateTimeUtil.localNow(),
+                startTimezone = "Asia/Seoul",
+                endDateTime = DateTimeUtil.localNow().plusDays(1),
+                endTimezone = "Asia/Seoul"
+            )
+        )
+
+        // when // then
+        mockMvc.post("/v1/content") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status {
+                    isOk()
+                }
+            }
+
+    }
+
+    @DisplayName("콘텐츠 생성 시 제목과 설명이 모두 비어있으면 실패한다.")
+    @Test
+    fun createContent_WithBlankTitleAndDescription() {
+        // given
+        val request = CreateContentRequest(
+            title = "",
+            description = "",
+            isCompleted = false,
+            tags = emptyList(),
+            dateTimeInfo = null
+        )
+
+        // when // then
+        mockMvc.post("/v1/content") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status { isBadRequest() }
+                jsonPath("$.error.code") { value(ContentExceptionCode.TITLE_OR_DESCRIPTION_REQUIRED.code) }
+            }
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- #53 

## 작업한 내용
- [x] 컨텐츠 생성 API
- [x] wishDate 쓰임 확인하고 반영 필요!
- [x] mvc test

## PR 포인트
- MemoCreator#createMemo 로직에서, content table에 저장하고 mapping table에 저장하는 부분 한번 봐주세요

## 기타
- 로컬에서 작업 환경 편하게 할 수 있는 방법이 없을까요? 현재는 매번 header에 accessToken을 얻어서 넣어주고 있어요
- POST 후 테이블 데이터를 보고싶은데, GET을 구현하는것 말고 따로 테이블을 볼 수 있는 방법이 있을까요?