### PR TITLE
[Refactor] entity id nullable -> null safety 0L로 수정

### DIFF
--- a/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/AuthService.kt
@@ -33,7 +33,7 @@ class AuthService(
             )
 
         val user = userProvider.findOrCreateUser(idToken)
-        val userId = user.id ?: throw GlobalException(GlobalExceptionCode.ARGS_VALIDATION_FAILED)
+        val userId = user.id
         val coupleId = user.couple?.id
 
         val serviceToken = createTokenAndSave(userId = userId)

--- a/src/main/kotlin/com/whatever/domain/calendarevent/eventrecurrence/model/ScheduleRecurrenceOverride.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/eventrecurrence/model/ScheduleRecurrenceOverride.kt
@@ -12,7 +12,7 @@ import java.time.ZoneId
 class ScheduleRecurrenceOverride(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/kotlin/com/whatever/domain/calendarevent/eventrecurrence/model/TaskRecurrenceOverride.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/eventrecurrence/model/TaskRecurrenceOverride.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 class TaskRecurrenceOverride(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/model/ScheduleEvent.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/model/ScheduleEvent.kt
@@ -13,7 +13,7 @@ import java.time.ZoneId
 class ScheduleEvent(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Column(nullable = false)
     val uid: String,

--- a/src/main/kotlin/com/whatever/domain/calendarevent/taskevent/model/TaskEvent.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/taskevent/model/TaskEvent.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 class TaskEvent(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Column(nullable = false)
     val uid: String,

--- a/src/main/kotlin/com/whatever/domain/content/model/Content.kt
+++ b/src/main/kotlin/com/whatever/domain/content/model/Content.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 class Content(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)

--- a/src/main/kotlin/com/whatever/domain/content/service/ContentService.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/ContentService.kt
@@ -29,6 +29,6 @@ class ContentService(
 }
 
 private fun Content.toContentSummaryResponse() = ContentSummaryResponse(
-    contentId = id!!,
+    contentId = id,
     contentType = type
 )

--- a/src/main/kotlin/com/whatever/domain/content/tag/model/Tag.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/model/Tag.kt
@@ -1,17 +1,13 @@
 package com.whatever.domain.content.tag.model
 
 import com.whatever.domain.base.BaseEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
+import jakarta.persistence.*
 
 @Entity
 class Tag (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Column(nullable = false, unique = true)
     val label: String

--- a/src/main/kotlin/com/whatever/domain/content/tag/model/TagContentMapping.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/model/TagContentMapping.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.*
 class TagContentMapping(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "tag_id", referencedColumnName = "id", nullable = false)

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 class Couple (
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     var startDate: LocalDate? = null,
 

--- a/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
@@ -58,16 +58,16 @@ class CoupleService(
         redisUtil.deleteCoupleInvitationCode(invitationCode, hostUserId)
 
         return CoupleDetailResponse(
-            coupleId = savedCouple.id!!,
+            coupleId = savedCouple.id,
             startDate = savedCouple.startDate,
             sharedMessage = savedCouple.sharedMessage,
             hostInfo = CoupleUserInfoDto(
-                id = hostUser.id!!,
+                id = hostUser.id,
                 nickname = hostUser.nickname!!,
                 birthDate = hostUser.birthDate!!
             ),
             partnerInfo = CoupleUserInfoDto(
-                id = partnerUser.id!!,
+                id = partnerUser.id,
                 nickname = partnerUser.nickname!!,
                 birthDate = partnerUser.birthDate!!
             ),

--- a/src/main/kotlin/com/whatever/domain/sample/model/SampleEntity.kt
+++ b/src/main/kotlin/com/whatever/domain/sample/model/SampleEntity.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.*
 class SampleEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Column(nullable = false, unique = true)
     val sampleAttribute: String,

--- a/src/main/kotlin/com/whatever/domain/sample/service/SampleService.kt
+++ b/src/main/kotlin/com/whatever/domain/sample/service/SampleService.kt
@@ -36,7 +36,7 @@ class SampleService(
         val testUser = userRepository.findByPlatformUserId(testPlatformId)
             ?: throw SampleNotFoundException(SampleExceptionCode.SAMPLE_CODE, "테스트 유저를 찾을 수 없습니다. 관리자에게 문의해주세요.")
 
-        val serviceToken = createTokenAndSave(userId = testUser.id!!, expSec)
+        val serviceToken = createTokenAndSave(userId = testUser.id, expSec)
         return SignInResponse(
             serviceToken = serviceToken,
             userStatus = testUser.userStatus,

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -9,7 +9,7 @@ import java.time.LocalDate
 class User(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    val id: Long = 0L,
 
     @Column(unique = true)
     var email: String? = null,

--- a/src/main/kotlin/com/whatever/global/security/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/whatever/global/security/filter/JwtAuthenticationFilter.kt
@@ -3,8 +3,6 @@ package com.whatever.global.security.filter
 import com.whatever.domain.auth.service.JwtHelper
 import com.whatever.domain.user.repository.UserRepository
 import com.whatever.global.security.principal.CaramelUserDetails
-import com.whatever.global.security.exception.AuthenticationException
-import com.whatever.global.security.exception.SecurityExceptionCode
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -45,7 +43,7 @@ class JwtAuthenticationFilter(
         val user = userRepository.findByIdOrNull(userId) ?: return null
 
         val userDetails = CaramelUserDetails(
-            userId = user.id!!,
+            userId = user.id,
             status = user.userStatus
         )
 


### PR DESCRIPTION
## 작업한 내용
- spring data jpa에서, entity @id에 Long  = 0L이어도 new라고 간주하여 새로운 id를 만들게 된다.
- null임이 자명함에도 불구하고 null safety한 코틀린에서 !!를 사용함에 있어 불편함이 많아 변경
![image](https://github.com/user-attachments/assets/9a0a9d5e-25e2-41ea-8b5f-c9e50c0d2775)


