### PR TITLE
[Feat] Authorization Header 필요없는 api swagger ui 변경

### DIFF
--- a/src/main/kotlin/com/whatever/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SwaggerConfig.kt
@@ -1,13 +1,17 @@
 package com.whatever.config
 
+import com.whatever.global.annotation.DisableSwaggerAuthButton
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.HandlerMethod
 
 @OpenAPIDefinition(
     info = Info(
@@ -38,4 +42,13 @@ class SwaggerConfig {
             .components(components)
     }
 
+    @Bean
+    fun operationCustomizer(): OperationCustomizer {
+        return OperationCustomizer { operation: Operation, handlerMethod: HandlerMethod ->
+            if (handlerMethod.hasMethodAnnotation(DisableSwaggerAuthButton::class.java)) {
+                operation.security = emptyList()
+            }
+            operation
+        }
+    }
 }

--- a/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/controller/AuthController.kt
@@ -4,6 +4,7 @@ import com.whatever.domain.auth.dto.ServiceToken
 import com.whatever.domain.auth.dto.SignInRequest
 import com.whatever.domain.auth.dto.SignInResponse
 import com.whatever.domain.auth.service.AuthService
+import com.whatever.global.annotation.DisableSwaggerAuthButton
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
 import io.swagger.v3.oas.annotations.Operation
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val authService: AuthService,
 ) {
+    @DisableSwaggerAuthButton
     @Operation(
         summary = "로그인 or 회원가입",
         description = "이미 회원인 경우 로그인을, 그렇지 않다면 회원가입을 진행합니다.",
@@ -43,6 +45,7 @@ class AuthController(
         return socialAuthResponse.succeed()
     }
 
+    @DisableSwaggerAuthButton
     @Operation(
         summary = "토큰 refresh",
         description = "새로운 accesstoken, refreshtoken 을 재발급합니다.",

--- a/src/main/kotlin/com/whatever/domain/sample/controller/SampleController.kt
+++ b/src/main/kotlin/com/whatever/domain/sample/controller/SampleController.kt
@@ -5,6 +5,7 @@ import com.whatever.domain.sample.exception.SampleExceptionCode
 import com.whatever.domain.sample.exception.SampleNotFoundException
 import com.whatever.domain.sample.service.SampleService
 import com.whatever.domain.user.model.UserGender
+import com.whatever.global.annotation.DisableSwaggerAuthButton
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.ErrorResponse
 import com.whatever.global.exception.dto.succeed
@@ -30,6 +31,7 @@ class SampleController(
     private val sampleService: SampleService,
 ) {
 
+    @DisableSwaggerAuthButton
     @Operation(
         summary = "기능명 기재",
         description = "기능 설명 기재",
@@ -44,6 +46,7 @@ class SampleController(
         return ResponseEntity.ok(result)
     }
 
+    @DisableSwaggerAuthButton
     @Operation(
         summary = "기능명 기재",
         description = "기능 설명 기재",
@@ -73,6 +76,7 @@ class SampleController(
      * 개발용 테스트 유저 로그인입니다.
      * 사용에 주의해주세요.
      */
+    @DisableSwaggerAuthButton
     @Operation(
         summary = "개발용 테스트 유저 로그인",
         description = "개발용 테스트 유저입니다."

--- a/src/main/kotlin/com/whatever/domain/sample/controller/SampleController.kt
+++ b/src/main/kotlin/com/whatever/domain/sample/controller/SampleController.kt
@@ -5,6 +5,7 @@ import com.whatever.domain.sample.exception.SampleExceptionCode
 import com.whatever.domain.sample.exception.SampleNotFoundException
 import com.whatever.domain.sample.service.SampleService
 import com.whatever.domain.user.model.UserGender
+import com.whatever.domain.user.model.UserStatus
 import com.whatever.global.annotation.DisableSwaggerAuthButton
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.ErrorResponse
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -84,5 +86,17 @@ class SampleController(
     @GetMapping("/test/sign-in")
     fun testSignIn(@RequestParam gender: UserGender, @RequestParam expSec: Long): CaramelApiResponse<SignInResponse> {
         return sampleService.testSignIn(gender, expSec).succeed()
+    }
+
+    @PreAuthorize("hasRole('SINGLE')")
+    @GetMapping("/is-single")
+    fun getSingle(): String {
+        return "single"
+    }
+
+    @PreAuthorize("hasRole('COUPLE')")
+    @GetMapping("/is-couple")
+    fun getCouple(): String {
+        return "couple"
     }
 }

--- a/src/main/kotlin/com/whatever/global/annotation/DisableSwaggerAuthButton.kt
+++ b/src/main/kotlin/com/whatever/global/annotation/DisableSwaggerAuthButton.kt
@@ -1,0 +1,8 @@
+package com.whatever.global.annotation
+
+/**
+ * Swagger-Ui Api의 인증 버튼을 비활성화하는 Annotation
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DisableSwaggerAuthButton

--- a/src/main/kotlin/com/whatever/global/exception/GlobalControllerAdvice.kt
+++ b/src/main/kotlin/com/whatever/global/exception/GlobalControllerAdvice.kt
@@ -8,6 +8,7 @@ import jakarta.servlet.ServletException
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.validation.BindException
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -29,6 +30,15 @@ class GlobalControllerAdvice : CaramelControllerAdvice() {
         return createExceptionResponse(errorCode = e.errorCode, debugMessage = e.detailMessage)
     }
 
+    @ExceptionHandler(AccessDeniedException::class)
+    fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<CaramelApiResponse<*>> {
+        logger.error(e) { "잘못된 접근 입니다." }
+        return createExceptionResponse(
+            errorCode = GlobalExceptionCode.ACCESS_DENIED,
+            debugMessage = e.message
+        )
+    }
+
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<CaramelApiResponse<*>> {
         logger.error(e) { "잘못된 인자가 전달되었습니다." }
@@ -46,7 +56,6 @@ class GlobalControllerAdvice : CaramelControllerAdvice() {
             debugMessage = e.message
         )
     }
-
 
     @ExceptionHandler(
         MethodArgumentNotValidException::class,
@@ -85,6 +94,10 @@ class GlobalControllerAdvice : CaramelControllerAdvice() {
 
     @ExceptionHandler(Exception::class)
     fun handleApplicationException(e: Exception): ResponseEntity<CaramelApiResponse<*>> {
+        if (e is AuthorizationDeniedException) {
+            // 이 예외는 전역 핸들러에서 처리하지 않고, 다시 던져서 스프링 시큐리티가 처리하도록 함
+            throw e
+        }
         logger.error(e) { "예상하지 못한 예외가 발생했습니다." }
         return createExceptionResponse(errorCode = GlobalExceptionCode.UNKNOWN)
     }

--- a/src/main/kotlin/com/whatever/global/exception/GlobalExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/exception/GlobalExceptionCode.kt
@@ -15,6 +15,7 @@ enum class GlobalExceptionCode(
     ARGS_TYPE_MISSMATCH( "003", "요청 타입이 올바르지 않습니다."),
     INVALID_ARGUMENT("004", "잘못된 인자가 전달되었습니다."),
     ILLEGAL_STATE("005", "잘못된 상태입니다."),
+    ACCESS_DENIED("006", "잘못된 접근 입니다."),
     ;
 
     override val code = "GLOBAL$sequence"


### PR DESCRIPTION
## 관련 이슈
- close #67 

## 작업한 내용
- Auth Header 설정 UI 제거
- UserStatus 권한별 sample get api 추가
