### PR TITLE
[Fix] user nickname 길이 제약조건 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### Custom ###
 .env
+src/main/resources/*.sql

--- a/src/main/kotlin/com/whatever/domain/user/dto/PostUserProfileRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/user/dto/PostUserProfileRequest.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
 data class PostUserProfileRequest(
     @Schema(description = "닉네임")
     @field:NotBlank(message = "닉네임은 공백일 수 없습니다.")
-    @field:Size(min = 3, max = 10, message = "닉네임은 3~10자 이내로 입력해주세요.")
+    @field:Size(min = 2, max = 8, message = "닉네임은 2~8자 이내로 입력해주세요.")
     @field:Pattern(regexp = "^[가-힣a-zA-Z0-9]+$")
     val nickname: String,
     @Schema(description = "YYYY-MM-DD 형식의 생일")

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -5,6 +5,7 @@ import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.user.exception.UserExceptionCode
 import com.whatever.domain.user.exception.UserIllegalStateException
 import jakarta.persistence.*
+import jakarta.validation.constraints.Size
 import java.time.LocalDate
 
 @Entity
@@ -24,6 +25,8 @@ class User(
     @Column(unique = true)
     val platformUserId: String,
 
+    @Size(min = 2, max = 8)
+    @Column(length = 8)
     var nickname: String? = null,
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/initial-data-local.sql
+++ b/src/main/resources/initial-data-local.sql
@@ -1,2 +1,0 @@
-INSERT INTO "user" ("birth_date", "is_deleted", "couple_id", "created_at", "id", "updated_at", "email", "gender", "nickname", "platform", "platform_user_id", "user_status")
-VALUES ('2025-03-03', false, null, '2025-03-06 02:07:45.000000', 1, '2025-03-06 02:07:49.000000', 'test@test.com', 'MALE', 'test user1', 'KAKAO', 'test-social-id', 'SINGLE');

--- a/src/test/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProviderTest.kt
+++ b/src/test/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProviderTest.kt
@@ -48,7 +48,7 @@ class KakaoUserProviderTest @Autowired constructor(
                 iat = 1L,
                 exp = 1L,
                 authTime = 1L,
-                nickname = "test  nick",
+                nickname = "testnick",
             ))
 
         // given

--- a/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
@@ -62,12 +62,12 @@ class UserControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("프로필을 등록할 때 닉네임은 3~10자여야 한다.")
+    @DisplayName("프로필을 등록할 때 닉네임은 1자 초과여야 한다.")
     @Test
     fun createProfile_WithBelowMinLengthNickname() {
         // given
         val request = PostUserProfileRequest(
-            nickname = "22",
+            nickname = "1",
             birthday = DateTimeUtil.localNow().toLocalDate(),
             agreementServiceTerms = true,
             agreementPrivatePolicy = true,
@@ -86,12 +86,12 @@ class UserControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("프로필을 등록할 때 닉네임은 11자 미만이어야 한다.")
+    @DisplayName("프로필을 등록할 때 닉네임은 9자 미만이어야 한다.")
     @Test
     fun createProfile_WithExceedingMaxLengthNickname() {
         // given
         val request = PostUserProfileRequest(
-            nickname = "12345678901",
+            nickname = "123456789",
             birthday = DateTimeUtil.localNow().toLocalDate(),
             agreementServiceTerms = true,
             agreementPrivatePolicy = true,


### PR DESCRIPTION
## 관련 이슈
- close #78 

## 작업한 내용
- 기존 3-10자를 디자인 기준인 2-8자로 변경
