### PR TITLE
[Fix] Profile Update시, nickname 필드가 Null일 때에도 validation하는 문제 수정

### DIFF
--- a/src/main/kotlin/com/whatever/domain/user/dto/PutUserProfileRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/user/dto/PutUserProfileRequest.kt
@@ -1,14 +1,15 @@
 package com.whatever.domain.user.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Size
+import jakarta.validation.constraints.Pattern
 import java.time.LocalDate
 
 data class PutUserProfileRequest(
     @Schema(description = "닉네임")
-    @field:NotBlank(message = "닉네임은 공백일 수 없습니다.")
-    @field:Size(min = 3, max = 10, message = "닉네임은 3~10자 이내로 입력해주세요.")
+    @field:Pattern(
+        regexp = "^(?!\\s*$)[가-힣a-zA-Z0-9]{3,10}$",
+        message = "닉네임은 3~10자의 한글, 영문, 숫자로만 입력해주세요."
+    )
     val nickname: String?,
 
     @Schema(description = "생일")

--- a/src/main/kotlin/com/whatever/domain/user/dto/PutUserProfileRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/user/dto/PutUserProfileRequest.kt
@@ -7,8 +7,8 @@ import java.time.LocalDate
 data class PutUserProfileRequest(
     @Schema(description = "닉네임")
     @field:Pattern(
-        regexp = "^$|[가-힣A-Za-z0-9]{3,10}$",
-        message = "닉네임은 3~10자의 한글, 영문, 숫자로만 입력해주세요."
+        regexp = "^$|[가-힣A-Za-z0-9]{2,8}$",
+        message = "닉네임은 2~8자의 한글, 영문, 숫자로만 입력해주세요."
     )
     val nickname: String?,
 

--- a/src/main/kotlin/com/whatever/domain/user/dto/PutUserProfileRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/user/dto/PutUserProfileRequest.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 data class PutUserProfileRequest(
     @Schema(description = "닉네임")
     @field:Pattern(
-        regexp = "^(?!\\s*$)[가-힣a-zA-Z0-9]{3,10}$",
+        regexp = "^$|[가-힣A-Za-z0-9]{3,10}$",
         message = "닉네임은 3~10자의 한글, 영문, 숫자로만 입력해주세요."
     )
     val nickname: String?,

--- a/src/main/kotlin/com/whatever/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/whatever/domain/user/service/UserService.kt
@@ -4,8 +4,6 @@ import com.whatever.domain.user.dto.PostUserProfileRequest
 import com.whatever.domain.user.dto.PostUserProfileResponse
 import com.whatever.domain.user.dto.PutUserProfileRequest
 import com.whatever.domain.user.dto.PutUserProfileResponse
-import com.whatever.domain.user.exception.UserException
-import com.whatever.domain.user.exception.UserExceptionCode
 import com.whatever.domain.user.repository.UserRepository
 import com.whatever.global.security.util.SecurityUtil.getCurrentUserId
 import org.springframework.data.repository.findByIdOrNull
@@ -36,7 +34,7 @@ class UserService(
     fun updateProfile(putUserProfileRequest: PutUserProfileRequest): PutUserProfileResponse {
         val userId = getCurrentUserId()
         val user = userRepository.findByIdOrNull(userId)?.apply {
-            if (putUserProfileRequest.nickname != null) {
+            if (putUserProfileRequest.nickname.isNullOrBlank().not()) {
                 nickname = putUserProfileRequest.nickname
             }
 
@@ -50,13 +48,5 @@ class UserService(
             nickname = user?.nickname!!,
             birthday = user.birthDate!!,
         )
-    }
-
-    private fun validateNickname(nickname: String) {
-        // 한글, 영문, 숫자 허용
-        val nicknameRegex = "^[가-힣a-zA-Z0-9]+$".toRegex()
-        if (!nicknameRegex.matches(nickname)) {
-            throw UserException(UserExceptionCode.INVALID_NICKNAME_CHARACTER)
-        }
     }
 }

--- a/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
@@ -3,15 +3,18 @@ package com.whatever.domain.user.controller
 import com.whatever.domain.ControllerTestSupport
 import com.whatever.domain.user.dto.PostUserProfileRequest
 import com.whatever.domain.user.dto.PutUserProfileRequest
+import com.whatever.domain.user.dto.PutUserProfileResponse
 import com.whatever.domain.user.model.UserGender
 import com.whatever.global.exception.GlobalExceptionCode
 import com.whatever.util.DateTimeUtil
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
-
+import java.time.LocalDate
 
 class UserControllerTest : ControllerTestSupport() {
 
@@ -230,5 +233,40 @@ class UserControllerTest : ControllerTestSupport() {
             .andExpect {
                 status { isOk() }
             }
+    }
+
+
+    @DisplayName("프로필 수정 시 nickname이 비어있을 경우 변경되지 않는다.")
+    @Test
+    fun updateProfile_WithBlankNickname_NoChange() {
+        @Test
+        fun updateProfile_WithBlankNickname_NoChange() {
+            val originalNickname = "변경전닉네임"
+            val originalBirthday = LocalDate.of(2025, 4, 20)
+            given(userService.updateProfile(any()))
+                .willReturn(
+                    PutUserProfileResponse(
+                        id = 1,
+                        nickname = originalNickname,
+                        birthday = originalBirthday
+                    )
+                )
+
+            val updateRequest = PutUserProfileRequest(
+                nickname = "",
+                birthday = null
+            )
+
+            // when // then
+            mockMvc.put("/v1/user/profile") {
+                content = objectMapper.writeValueAsString(updateRequest)
+                contentType = MediaType.APPLICATION_JSON
+            }
+                .andDo { print() }
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.nickname") { value(originalNickname) }
+                }
+        }
     }
 }

--- a/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
@@ -192,4 +192,43 @@ class UserControllerTest : ControllerTestSupport() {
                 jsonPath("$.error.code") { value(GlobalExceptionCode.ARGS_VALIDATION_FAILED.code) }
             }
     }
+
+    @DisplayName("프로필 수정 시 nickname이 null이고 birthday만 있을 경우 생일만 업데이트된다.")
+    @Test
+    fun updateProfile_OnlyBirthday() {
+        // given
+        val request = PutUserProfileRequest(
+            nickname = null,
+            birthday = DateTimeUtil.localNow().toLocalDate().plusDays(2),
+        )
+
+        // when // then
+        mockMvc.put("/v1/user/profile") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @DisplayName("프로필 수정 시 birthday가 null이고 nickname만 있을 경우 닉네임만 업데이트된다.")
+    @Test
+    fun updateProfile_OnlyNickname() {
+        val request = PutUserProfileRequest(
+            nickname = "새닉네임",
+            birthday = null,
+        )
+
+        // when // then
+        mockMvc.put("/v1/user/profile") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status { isOk() }
+            }
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- #88 

## 작업한 내용
- Regex 사용하도록 변경

## PR 포인트
- 기존 Size, NotBlank 사용하는 편이 좀더 직관적이었던 것 같은데, 따로 방법이 생각나지 않아서 REGEX 사용했습니다.