### PR TITLE
[Refactor] 커플 Entity 상태식별 컬럼 추가, 수정사항에 따른 couple api 수정

### DIFF
--- a/src/main/kotlin/com/whatever/domain/couple/controller/CoupleController.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/controller/CoupleController.kt
@@ -5,12 +5,11 @@ import com.whatever.domain.couple.controller.dto.request.UpdateCoupleSharedMessa
 import com.whatever.domain.couple.controller.dto.request.UpdateCoupleStartDateRequest
 import com.whatever.domain.couple.controller.dto.response.CoupleBasicResponse
 import com.whatever.domain.couple.controller.dto.response.CoupleInvitationCodeResponse
-import com.whatever.domain.couple.controller.dto.response.CoupleUserInfoDto
 import com.whatever.domain.couple.controller.dto.response.CoupleDetailResponse
 import com.whatever.domain.couple.service.CoupleService
+import com.whatever.global.constants.CaramelHttpHeaders.TIME_ZONE
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
-import com.whatever.util.DateTimeUtil
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -70,8 +70,9 @@ class CoupleController(
     fun updateCoupleStartDate(
         @PathVariable("couple-id") coupleId: Long,
         @RequestBody request: UpdateCoupleStartDateRequest,
+        @RequestHeader(TIME_ZONE) timeZone: String,
     ): CaramelApiResponse<CoupleBasicResponse> {
-        val response = coupleService.updateStartDate(coupleId, request)
+        val response = coupleService.updateStartDate(coupleId, request, timeZone)
         return response.succeed()
     }
 

--- a/src/main/kotlin/com/whatever/domain/couple/controller/dto/response/CoupleInfoResponse.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/controller/dto/response/CoupleInfoResponse.kt
@@ -1,6 +1,7 @@
 package com.whatever.domain.couple.controller.dto.response
 
 import com.whatever.domain.couple.model.Couple
+import com.whatever.domain.couple.model.CoupleStatus
 import com.whatever.domain.user.model.User
 import com.whatever.domain.user.model.UserGender
 import io.swagger.v3.oas.annotations.media.Schema
@@ -12,6 +13,7 @@ data class CoupleDetailResponse(
     @Schema(description = "커플 시작일")
     val startDate: LocalDate?,
     val sharedMessage: String?,
+    val status: CoupleStatus,
     @Schema(description = "내 정보")
     val myInfo: CoupleUserInfoDto,
     @Schema(description = "상대방 정보")
@@ -23,6 +25,7 @@ data class CoupleDetailResponse(
                 coupleId = couple.id,
                 startDate = couple.startDate,
                 sharedMessage = couple.sharedMessage,
+                status = couple.status,
                 myInfo = CoupleUserInfoDto.from(myUser),
                 partnerInfo = CoupleUserInfoDto.from(partnerUser),
             )
@@ -35,6 +38,7 @@ data class CoupleBasicResponse(
     val coupleId: Long,
     val startDate: LocalDate?,
     val sharedMessage: String?,
+    val status: CoupleStatus,
 ) {
     companion object {
         fun from(couple: Couple): CoupleBasicResponse {
@@ -42,6 +46,7 @@ data class CoupleBasicResponse(
                 coupleId = couple.id,
                 startDate = couple.startDate,
                 sharedMessage = couple.sharedMessage,
+                status = couple.status,
             )
         }
     }

--- a/src/main/kotlin/com/whatever/domain/couple/controller/dto/response/CoupleInfoResponse.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/controller/dto/response/CoupleInfoResponse.kt
@@ -2,6 +2,7 @@ package com.whatever.domain.couple.controller.dto.response
 
 import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.UserGender
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -50,14 +51,16 @@ data class CoupleBasicResponse(
 data class CoupleUserInfoDto(
     val id: Long,
     val nickname: String,
-    val birthDate: LocalDate
+    val birthDate: LocalDate,
+    val gender: UserGender,
 ) {
     companion object {
         fun from(user: User): CoupleUserInfoDto {
             return CoupleUserInfoDto(
                 id = user.id,
                 nickname = user.nickname!!,
-                birthDate = user.birthDate!!
+                birthDate = user.birthDate!!,
+                gender = user.gender!!,
             )
         }
     }

--- a/src/main/kotlin/com/whatever/domain/couple/exception/CoupleAccessDeniedException.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/exception/CoupleAccessDeniedException.kt
@@ -1,6 +1,0 @@
-package com.whatever.domain.couple.exception
-
-class CoupleAccessDeniedException(
-    errorCode: CoupleExceptionCode,
-    detailMessage: String? = null
-) : CoupleException(errorCode, detailMessage)

--- a/src/main/kotlin/com/whatever/domain/couple/exception/CoupleException.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/exception/CoupleException.kt
@@ -6,3 +6,18 @@ open class CoupleException(
     errorCode: CoupleExceptionCode,
     detailMessage: String? = null
 ) : CaramelException(errorCode, detailMessage)
+
+class CoupleAccessDeniedException(
+    errorCode: CoupleExceptionCode,
+    detailMessage: String? = null
+) : CoupleException(errorCode, detailMessage)
+
+class CoupleIllegalStateException(
+    errorCode: CoupleExceptionCode,
+    detailMessage: String? = null
+) : CoupleException(errorCode, detailMessage)
+
+class CoupleIllegalArgumentException(
+    errorCode: CoupleExceptionCode,
+    detailMessage: String? = null
+) : CoupleException(errorCode, detailMessage)

--- a/src/main/kotlin/com/whatever/domain/couple/exception/CoupleExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/exception/CoupleExceptionCode.kt
@@ -18,6 +18,7 @@ enum class CoupleExceptionCode(
     NOT_A_MEMBER("007", "커플에 속한 유저가 아닙니다."),
     ILLEGAL_MEMBER_SIZE("008", "커플에는 반드시 두 명의 유저가 있어야 합니다."),
     UPDATE_FAIL("009", "상대방이 수정 중입니다. 잠시 후 재시도 해주세요."),
+    ILLEGAL_START_DATE("010", "커플 시작일은 오늘 이전이어야 합니다."),
     ;
 
     override val code = "COUPLE$sequence"

--- a/src/main/kotlin/com/whatever/domain/couple/exception/CoupleIllegalStateException.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/exception/CoupleIllegalStateException.kt
@@ -1,6 +1,0 @@
-package com.whatever.domain.couple.exception
-
-class CoupleIllegalStateException(
-    errorCode: CoupleExceptionCode,
-    detailMessage: String? = null
-) : CoupleException(errorCode, detailMessage)

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -21,6 +21,9 @@ class Couple (
     var startDate: LocalDate? = null,
 
     var sharedMessage: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    var status: CoupleStatus = CoupleStatus.ACTIVE,
 ) : BaseEntity() {
 
     @OneToMany(mappedBy = "_couple", fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -1,11 +1,16 @@
 package com.whatever.domain.couple.model
 
 import com.whatever.domain.base.BaseEntity
+import com.whatever.domain.couple.exception.CoupleExceptionCode
 import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_MEMBER_SIZE
+import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_START_DATE
+import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
 import com.whatever.domain.couple.exception.CoupleIllegalStateException
 import com.whatever.domain.user.model.User
+import com.whatever.util.DateTimeUtil
 import jakarta.persistence.*
 import java.time.LocalDate
+import java.time.ZoneId
 
 @Entity
 class Couple (
@@ -29,7 +34,12 @@ class Couple (
         mutableMembers.add(user)
     }
 
-    fun updateStartDate(newDate: LocalDate) {
+    fun updateStartDate(newDate: LocalDate, userZoneId: ZoneId) {
+        val todayInUserZone = DateTimeUtil.zonedNow(userZoneId).toLocalDate()
+        if (newDate.isAfter(todayInUserZone)) {
+            throw CoupleIllegalArgumentException(errorCode = ILLEGAL_START_DATE)
+        }
+
         startDate = newDate
     }
 

--- a/src/main/kotlin/com/whatever/domain/couple/model/CoupleStatus.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/CoupleStatus.kt
@@ -1,0 +1,6 @@
+package com.whatever.domain.couple.model
+
+enum class CoupleStatus {
+    ACTIVE,
+    INACTIVE,
+}

--- a/src/main/kotlin/com/whatever/global/constants/CaramelHttpHeader.kt
+++ b/src/main/kotlin/com/whatever/global/constants/CaramelHttpHeader.kt
@@ -1,0 +1,7 @@
+package com.whatever.global.constants
+
+import org.springframework.http.HttpHeaders
+
+object CaramelHttpHeaders {
+    const val TIME_ZONE = "Time-Zone"
+}

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceOptimisticLockTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceOptimisticLockTest.kt
@@ -76,12 +76,13 @@ class CoupleServiceOptimisticLockTest @Autowired constructor(
             LocalDate.EPOCH.plusDays(idx.toLong())
         }
         val requests = startDates.map { UpdateCoupleStartDateRequest(it) }
+        val timeZone = "Asia/Seoul"
 
         val futures = requests.mapIndexed { idx, request ->
             CompletableFuture.supplyAsync({
                 mockStatic(SecurityUtil::class.java).use {
                     it.apply { whenever(SecurityUtil.getCurrentUserId()).doReturn(members[idx].id) }
-                    coupleService.updateStartDate(savedCouple.id, request)
+                    coupleService.updateStartDate(savedCouple.id, request, timeZone)
                 }
             }, executor)
         }
@@ -109,10 +110,11 @@ class CoupleServiceOptimisticLockTest @Autowired constructor(
         whenever(coupleRepository.findByIdOrNull(any())).doThrow(ObjectOptimisticLockingFailureException::class)
 
         val request = UpdateCoupleStartDateRequest(LocalDate.EPOCH)
+        val timeZone = "Asia/Seoul"
 
         // when
         val exception = assertThrows<CoupleIllegalStateException> {
-            coupleService.updateStartDate(savedCouple.id, request)
+            coupleService.updateStartDate(savedCouple.id, request, timeZone)
         }
 
         // then
@@ -165,12 +167,13 @@ class CoupleServiceOptimisticLockTest @Autowired constructor(
 
         val updateStartDateRequest = UpdateCoupleStartDateRequest(LocalDate.EPOCH)
         val updateSharedMessageRequest = UpdateCoupleSharedMessageRequest("updated sharedMessage")
+        val timeZone = "Asia/Seoul"
 
         val futures = listOf(
             CompletableFuture.supplyAsync({
                 mockStatic(SecurityUtil::class.java).use {
                     it.apply { whenever(SecurityUtil.getCurrentUserId()).doReturn(myUser.id) }
-                    coupleService.updateStartDate(savedCouple.id, updateStartDateRequest)
+                    coupleService.updateStartDate(savedCouple.id, updateStartDateRequest, timeZone)
                 }
             }, executor),
             CompletableFuture.supplyAsync({

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
@@ -8,6 +8,7 @@ import com.whatever.domain.couple.exception.CoupleException
 import com.whatever.domain.couple.exception.CoupleExceptionCode
 import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
 import com.whatever.domain.couple.model.Couple
+import com.whatever.domain.couple.model.CoupleStatus
 import com.whatever.domain.couple.repository.CoupleRepository
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
@@ -234,12 +235,11 @@ class CoupleServiceTest @Autowired constructor(
         }
         whenever(redisUtil.getCoupleInvitationUser(request.invitationCode)).doReturn(hostUser.id)
 
-
         // when
         val result = coupleService.createCouple(request)
 
-
         // then
+        assertThat(result.status).isEqualTo(CoupleStatus.ACTIVE)
         assertThat(result.myInfo.id).isEqualTo(myUser.id)
         assertThat(result.partnerInfo.id).isEqualTo(hostUser.id)
     }

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
@@ -9,6 +9,7 @@ import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.couple.repository.CoupleRepository
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.UserGender
 import com.whatever.domain.user.model.UserStatus
 import com.whatever.domain.user.repository.UserRepository
 import com.whatever.global.security.util.SecurityUtil
@@ -165,7 +166,9 @@ class CoupleServiceTest @Autowired constructor(
         // then
         assertThat(result.coupleId).isEqualTo(savedCouple.id)
         assertThat(result.myInfo.id).isEqualTo(myUser.id)
+        assertThat(result.myInfo.gender).isEqualTo(myUser.gender!!)
         assertThat(result.partnerInfo.id).isEqualTo(partnerUser.id)
+        assertThat(result.partnerInfo.gender).isEqualTo(partnerUser.gender!!)
     }
 
     @DisplayName("Couple의 member가 아닌 유저가 정보를 조회할 경우 예외를 반환한다.")
@@ -347,7 +350,8 @@ internal fun makeCouple(userRepository: UserRepository, coupleRepository: Couple
             birthDate = DateTimeUtil.localNow().toLocalDate(),
             platform = LoginPlatform.KAKAO,
             platformUserId = "my-user-id",
-            userStatus = UserStatus.SINGLE
+            userStatus = UserStatus.SINGLE,
+            gender = UserGender.MALE,
         )
     )
     val partnerUser = userRepository.save(
@@ -356,7 +360,8 @@ internal fun makeCouple(userRepository: UserRepository, coupleRepository: Couple
             birthDate = DateTimeUtil.localNow().toLocalDate(),
             platform = LoginPlatform.KAKAO,
             platformUserId = "partner-user-id",
-            userStatus = UserStatus.SINGLE
+            userStatus = UserStatus.SINGLE,
+            gender = UserGender.FEMALE,
         )
     )
 

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
@@ -208,7 +208,8 @@ class CoupleServiceTest @Autowired constructor(
                 birthDate = DateTimeUtil.localNow().toLocalDate(),
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "my-user-id",
-                userStatus = UserStatus.SINGLE
+                userStatus = UserStatus.SINGLE,
+                gender = UserGender.MALE,
             )
         )
         val hostUser = userRepository.save(
@@ -217,7 +218,8 @@ class CoupleServiceTest @Autowired constructor(
                 birthDate = DateTimeUtil.localNow().toLocalDate(),
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "host-user-id",
-                userStatus = UserStatus.SINGLE
+                userStatus = UserStatus.SINGLE,
+                gender = UserGender.FEMALE,
             )
         )
         val request = CreateCoupleRequest("test-invitation-code")
@@ -276,9 +278,9 @@ class CoupleServiceTest @Autowired constructor(
             whenever(SecurityUtil.getCurrentUserId()).doReturn(myUser.id)
         }
         val request = UpdateCoupleStartDateRequest(DateTimeUtil.localNow().toLocalDate())
-
+        val timeZone = "Asia/Seoul"
         // when
-        val result = coupleService.updateStartDate(savedCouple.id, request)
+        val result = coupleService.updateStartDate(savedCouple.id, request, timeZone)
 
         // then
         assertThat(result.coupleId).isEqualTo(savedCouple.id)


### PR DESCRIPTION
## 관련 이슈
- close #85 

## 작업한 내용
- couple start date 수정 시 미래의 date를 넣을 수 없도록 변경했습니다.
- couple entity에 status값을 추가했습니다.
- CoupleUserInfoDto에 성별 정보를 추가했습니다.

## PR 포인트
- Couple.status를 추가했습니다. 
- 해당 상태에 대한 정합성 관리가 필요하다는 단점이 있겠지만, 1. 직관적이고 2. 비즈니스 상태와 멤버의 수는 분리하는 편이 확장성에도 도움이 될 것 같다고 판단했습니다.