### PR TITLE
[Fix] sample signin api Tx문제 해결

### DIFF
--- a/src/main/kotlin/com/whatever/domain/sample/service/SampleService.kt
+++ b/src/main/kotlin/com/whatever/domain/sample/service/SampleService.kt
@@ -56,6 +56,7 @@ class SampleService(
         )
     }
 
+    @Transactional
     fun createNewDummyAccount(testEmail: String?): String {
         val dummyUser = User(
             platform = LoginPlatform.TEST,
@@ -66,6 +67,7 @@ class SampleService(
         return dummyUser.email!!
     }
 
+    @Transactional
     fun createSingleDummyAccount(
         testEmail: String?,
         testNickname: String?,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -166,10 +166,6 @@ spring:
         format_sql: true
         show_sql: true
     defer-datasource-initialization: true
-  sql:
-    init:
-      mode: always
-      data-locations: classpath:initial-data-local.sql
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## 관련 이슈
- close #95 

## 작업한 내용
- createAccount 메서드에  `@Tx` 적용
- 사용하지 않는 sql-init 제거

## PR 포인트
- `@Transactional`의 `readOnly` 설정 값은 강제가 아니라는 사실을 몰랐었습니다..!

H2가 사용하는 JdbcConnection의 경우 아래와 같이 setReadOnly값을무시합니다.
따라서 별도의 읽기 전용 옵션으로 H2서버를 실행하지 않는 이상 readOnly Tx에서 write를 진행하도 오류가 나지 않습니다.
그래서 로컬에서 돌려보았을 때 파악하지 못했고, 앞으로 좀 더 주의하겠습니다.
```java
/** 
                        JdbcConnection.java
**/

    /**
     * According to the JDBC specs, this setting is only a hint to the database
     * to enable optimizations - it does not cause writes to be prohibited.
     *
     * @param readOnly ignored
     * @throws SQLException if the connection is closed
     */
    @Override
    public void setReadOnly(boolean readOnly) throws SQLException {
        try {
            if (isDebugEnabled()) {
                debugCode("setReadOnly(" + readOnly + ')');
            }
            checkClosed();
        } catch (Exception e) {
            throw logAndConvert(e);
        }
    }

    /**
     * Returns true if the database is read-only.
     *
     * @return if the database is read-only
     * @throws SQLException if the connection is closed
     */
    @Override
    public boolean isReadOnly() throws SQLException {
        try {
            debugCodeCall("isReadOnly");
            checkClosed();
            getReadOnly = prepareCommand("CALL READONLY()", getReadOnly);  // H2 Database가 readOnly mode로 열려있지 않아 항상 false를 반환
            ResultInterface result = getReadOnly.executeQuery(0, false);
            result.next();
            return result.currentRow()[0].getBoolean();
        } catch (Exception e) {
            throw logAndConvert(e);
        }
    }
```
```java
/** 
                        PgConnection.java
**/
  @Override
  public void setReadOnly(boolean readOnly) throws SQLException {
    checkClosed();
    if (queryExecutor.getTransactionState() != TransactionState.IDLE) {
      throw new PSQLException(
          GT.tr("Cannot change transaction read-only property in the middle of a transaction."),
          PSQLState.ACTIVE_SQL_TRANSACTION);
    }

    if (readOnly != this.readOnly && autoCommit && this.readOnlyBehavior == ReadOnlyBehavior.always) {
      execSQLUpdate(readOnly ? setSessionReadOnly : setSessionNotReadOnly);
    }

    this.readOnly = readOnly;  // 1. readOnly값을 세팅
    LOGGER.log(Level.FINE, "  setReadOnly = {0}", readOnly);
  }

  @Override
  public boolean isReadOnly() throws SQLException {
    checkClosed();
    return readOnly;  // 2. TxManager에서 Connection을 얻어올 때 반영
  }
```