### PR TITLE
[Feat] schedule 생성 api 추가, 일정 조회에서 기간 조회가 가능하도록 수정

### DIFF
--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -87,6 +87,11 @@ class SecurityConfig(
                 authorize("/v1/couples/connect", hasAnyRole(SINGLE.name))
                 authorize("/v1/couples/**", hasAnyRole(COUPLED.name))
 
+                authorize("/v1/calendar/holidays", hasAnyRole(COUPLED.name))
+                authorize("/v1/calendar/schedules/**", hasAnyRole(COUPLED.name))
+
+                authorize("/v1/calendar/**", hasAnyRole(COUPLED.name))
+
                 authorize(anyRequest, permitAll)  // TODO(준용) API에 따른 Role 추가 필요, 현재 임시로 모두 허용
             }
         }

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/ScheduleController.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/ScheduleController.kt
@@ -1,8 +1,11 @@
 package com.whatever.domain.calendarevent.scheduleevent.controller
 
+import com.whatever.domain.calendarevent.scheduleevent.controller.dto.CreateScheduleRequest
 import com.whatever.domain.calendarevent.scheduleevent.controller.dto.UpdateScheduleRequest
 import com.whatever.domain.calendarevent.scheduleevent.service.ScheduleEventService
+import com.whatever.domain.content.controller.dto.response.ContentSummaryResponse
 import com.whatever.global.exception.dto.CaramelApiResponse
+import com.whatever.global.exception.dto.succeed
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -17,6 +20,20 @@ import org.springframework.web.bind.annotation.*
 class ScheduleController(
     private val scheduleEventService: ScheduleEventService
 ) {
+
+    @Operation(
+        summary = "일정 생성",
+        description = "일정을 생성합니다.",
+    )
+    @PostMapping
+    fun createSchedule(
+        @Valid @RequestBody request: CreateScheduleRequest,
+    ): CaramelApiResponse<ContentSummaryResponse> {
+        val response = scheduleEventService.createSchedule(
+            request = request,
+        )
+        return response.succeed()
+    }
 
     @Operation(
         summary = "일정 수정",

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/ScheduleController.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/ScheduleController.kt
@@ -23,7 +23,7 @@ class ScheduleController(
 
     @Operation(
         summary = "일정 생성",
-        description = "일정을 생성합니다.",
+        description = "기존에 존재하던 콘텐츠(MEMO)를 바탕으로 일정을 생성합니다.",
     )
     @PostMapping
     fun createSchedule(

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
@@ -2,7 +2,6 @@ package com.whatever.domain.calendarevent.scheduleevent.controller.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "일정 생성 요청 모델")
@@ -10,9 +9,6 @@ data class CreateScheduleRequest(
 
     @Schema(description = "콘텐츠(메모) id", example = "1")
     val contentId: Long,
-
-    @Schema(description = "선택한 일자", example = "2025-02-16")
-    val selectedDate: LocalDate,
 
     @Schema(description = "콘텐츠 제목. title, description 둘 중 하나는 필수입니다.", example = "맛집 리스트", nullable = true)
     @field:NotBlank(message = "제목은 공백일 수 없습니다.")

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
@@ -1,0 +1,42 @@
+package com.whatever.domain.calendarevent.scheduleevent.controller.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Schema(description = "일정 생성 요청 모델")
+data class CreateScheduleRequest(
+
+    @Schema(description = "콘텐츠(메모) id", example = "1")
+    val contentId: Long,
+
+    @Schema(description = "선택한 일자", example = "2025-02-16")
+    val selectedDate: LocalDate,
+
+    @Schema(description = "콘텐츠 제목. title, description 둘 중 하나는 필수입니다.", example = "맛집 리스트", nullable = true)
+    @field:NotBlank(message = "제목은 공백일 수 없습니다.")
+    val title: String? = null,
+
+    @Schema(description = "콘텐츠 설명. title, description 둘 중 하나는 필수입니다.", example = "어제 함께 갔던 맛집들", nullable = true)
+    @field:NotBlank(message = "본문은 공백일 수 없습니다.")
+    val description: String? = null,
+
+    @Schema(description = "완료 여부")
+    val isCompleted: Boolean,
+
+    @Schema(description = "시작일", example = "2025-02-16T18:26:40")
+    val startDateTime: LocalDateTime,
+
+    @Schema(description = "시작일 타임존", example = "Asia/Seoul")
+    val startTimeZone: String,
+
+    @Schema(description = "종료일", example = "2025-02-16T23:59:59", nullable = true)
+    val endDateTime: LocalDateTime? = null,
+
+    @Schema(description = "종료일 타임존", example = "Asia/Seoul", nullable = true)
+    val endTimeZone: String? = null,
+
+    @Schema(description = "태그 번호 리스트")
+    val tagIds: Set<Long> = emptySet(),
+)

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-@Schema(description = "콘텐츠 생성 요청 모델")
+@Schema(description = "일정 업데이트 요청 모델")
 data class UpdateScheduleRequest(
 
     @Schema(description = "선택한 일자", example = "2025-02-16")

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/exception/ScheduleExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/exception/ScheduleExceptionCode.kt
@@ -16,6 +16,7 @@ enum class ScheduleExceptionCode(
     ILLEGAL_PARTNER_STATUS("004", "파트너의 커플 정보를 확인할 수 없습니다.", HttpStatus.NOT_FOUND),
     COUPLE_NOT_MATCHED("005", "수정할 수 없는 일정입니다.", HttpStatus.FORBIDDEN),
     UPDATE_CONFLICT("006", "상대방이 수정 중인 일정입니다. 잠시 후 재시도 해주세요.", HttpStatus.CONFLICT),
+    ILLEGAL_CONTENT_ID("007", "사용할 수 없는 콘텐츠입니다."),
     ;
 
     override val code = "SCHEDULE$sequence"

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/repository/ScheduleEventRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/repository/ScheduleEventRepository.kt
@@ -11,7 +11,7 @@ interface ScheduleEventRepository : JpaRepository<ScheduleEvent, Long> {
             join fetch se.content c
             join c.user u
         where se.isDeleted = false
-            and (se.startDateTime >= :startDateTime or se.endDateTime <= :endDateTime)
+            and (se.startDateTime <= :endDateTime and se.endDateTime >= :startDateTime)
             and u.id in :memberIds
         order by se.startDateTime
     """)

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventService.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventService.kt
@@ -310,7 +310,7 @@ class ScheduleEventService(
 
 private fun CreateScheduleRequest.toUpdateRequest(): UpdateScheduleRequest {
     return UpdateScheduleRequest(
-        selectedDate = selectedDate,
+        selectedDate = startDateTime.toLocalDate(),
         title = title,
         description = description,
         isCompleted = isCompleted,

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventService.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventService.kt
@@ -127,8 +127,8 @@ class ScheduleEventService(
             )
         }
 
+        content.type = ContentType.SCHEDULE
         val scheduleEvent = with(request) {
-            content.type = ContentType.SCHEDULE
             ScheduleEvent(
                 content = content,
                 uid = UUID.randomUUID().toString(),

--- a/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventCreateServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventCreateServiceTest.kt
@@ -90,7 +90,6 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
 
         val request = CreateScheduleRequest(
             contentId = memo.id,
-            selectedDate = DateTimeUtil.localNow().toLocalDate(),
             title = "Schedule Title",
             description = "Description Content",
             isCompleted = false,
@@ -121,7 +120,6 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
         setUpCoupleAndSecurity()
         val request = CreateScheduleRequest(
             contentId = 0L, // 존재하지 않는 ID
-            selectedDate = DateTimeUtil.localNow().toLocalDate(),
             title = "title",
             description = "desc",
             isCompleted = false,
@@ -143,7 +141,6 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
         val nonMemo = contentRepository.save(createContent(myUser, ContentType.SCHEDULE))
         val request = CreateScheduleRequest(
             contentId = nonMemo.id,
-            selectedDate = DateTimeUtil.localNow().toLocalDate(),
             title = "title",
             description = "desc",
             isCompleted = false,
@@ -170,7 +167,6 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
         }
         val request = CreateScheduleRequest(
             contentId = memo.id,
-            selectedDate = DateTimeUtil.localNow().toLocalDate(),
             title = "title",
             description = "desc",
             isCompleted = false,
@@ -199,7 +195,6 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
         val memo = contentRepository.save(createContent(myUser, ContentType.MEMO))
         val request = CreateScheduleRequest(
             contentId = memo.id,
-            selectedDate = DateTimeUtil.localNow().toLocalDate(),
             title = title,
             description = description,
             isCompleted = false,
@@ -221,7 +216,6 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
         val memo = contentRepository.save(createContent(myUser, ContentType.MEMO))
         val request = CreateScheduleRequest(
             contentId = memo.id,
-            selectedDate = DateTimeUtil.localNow().toLocalDate(),
             title = "title",
             description = "desc",
             isCompleted = false,

--- a/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventCreateServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventCreateServiceTest.kt
@@ -1,0 +1,239 @@
+package com.whatever.domain.calendarevent.scheduleevent.service
+
+import com.whatever.domain.calendarevent.scheduleevent.controller.dto.CreateScheduleRequest
+import com.whatever.domain.calendarevent.scheduleevent.exception.ScheduleAccessDeniedException
+import com.whatever.domain.calendarevent.scheduleevent.exception.ScheduleExceptionCode
+import com.whatever.domain.calendarevent.scheduleevent.exception.ScheduleIllegalArgumentException
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import com.whatever.domain.content.model.ContentType
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import com.whatever.domain.content.tag.repository.TagRepository
+import com.whatever.domain.couple.model.Couple
+import com.whatever.domain.couple.repository.CoupleRepository
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.global.security.util.SecurityUtil
+import com.whatever.util.DateTimeUtil
+import com.whatever.util.findByIdAndNotDeleted
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ScheduleEventServiceCreateTest @Autowired constructor(
+    private val coupleRepository: CoupleRepository,
+    private val userRepository: UserRepository,
+    private val scheduleEventRepository: ScheduleEventRepository,
+    private val contentRepository: ContentRepository,
+    private val tagContentMappingRepository: TagContentMappingRepository,
+    private val tagRepository: TagRepository,
+    private val scheduleEventService: ScheduleEventService,
+) {
+
+    companion object {
+        val NOW = DateTimeUtil.localNow()
+    }
+
+    private lateinit var securityUtilMock: AutoCloseable
+
+    @BeforeEach
+    fun setUp() {
+        securityUtilMock = mockStatic(SecurityUtil::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        securityUtilMock.close()
+        tagContentMappingRepository.deleteAllInBatch()
+        tagRepository.deleteAllInBatch()
+        scheduleEventRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+    }
+
+    private fun setUpCoupleAndSecurity(
+        myPlatformId: String = "my-user-id",
+        partnerPlatformId: String = "partner-user-id"
+    ): Triple<User, User, Couple> {
+        val (myUser, partnerUser, couple) = createCouple(
+            userRepository,
+            coupleRepository,
+            myPlatformId,
+            partnerPlatformId
+        )
+        securityUtilMock.apply {
+            whenever(SecurityUtil.getCurrentUserId()).thenReturn(myUser.id)
+            whenever(SecurityUtil.getCurrentUserCoupleId()).thenReturn(couple.id)
+        }
+        return Triple(myUser, partnerUser, couple)
+    }
+
+    @DisplayName("MEMO 타입 컨텐츠에서 정상적으로 Schedule 생성에 성공한다.")
+    @Test
+    fun createSchedule() {
+        // given
+        val (myUser, _, _) = setUpCoupleAndSecurity()
+        val memo = contentRepository.save(createContent(myUser, ContentType.MEMO))
+
+        val request = CreateScheduleRequest(
+            contentId = memo.id,
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = "Schedule Title",
+            description = "Description Content",
+            isCompleted = false,
+            startDateTime = NOW,
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
+            endDateTime = NOW.plusDays(2),
+            endTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
+        )
+
+        // when
+        val result = scheduleEventService.createSchedule(request)
+
+        // then
+        val scheduleEvent = scheduleEventRepository.findByIdAndNotDeleted(result.contentId)
+        val content = contentRepository.findByIdAndNotDeleted(memo.id)
+        require(scheduleEvent != null)
+        require(content != null)
+        assertThat(scheduleEvent.content.id).isEqualTo(memo.id)
+        assertThat(content.type).isEqualTo(ContentType.SCHEDULE)
+        assertThat(content.contentDetail.title).isEqualTo(request.title)
+        assertThat(content.contentDetail.description).isEqualTo(request.description)
+    }
+
+    @DisplayName("존재하지 않거나 삭제된 contentId 입력 시 예외가 발생한다.")
+    @Test
+    fun createSchedule_WithIllegalContentId() {
+        // given
+        setUpCoupleAndSecurity()
+        val request = CreateScheduleRequest(
+            contentId = 0L, // 존재하지 않는 ID
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = "title",
+            description = "desc",
+            isCompleted = false,
+            startDateTime = NOW,
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id
+        )
+        // when, then
+        val exception = assertThrows<ScheduleIllegalArgumentException> {
+            scheduleEventService.createSchedule(request)
+        }
+        assertThat(exception).hasMessage(ScheduleExceptionCode.ILLEGAL_CONTENT_ID.message)
+    }
+
+    @DisplayName("MEMO 타입이 아닌 컨텐츠에서 생성 요청 시 예외가 발생한다.")
+    @Test
+    fun createSchedule_WithNonMemoContent() {
+        // given
+        val (myUser, _, _) = setUpCoupleAndSecurity()
+        val nonMemo = contentRepository.save(createContent(myUser, ContentType.SCHEDULE))
+        val request = CreateScheduleRequest(
+            contentId = nonMemo.id,
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = "title",
+            description = "desc",
+            isCompleted = false,
+            startDateTime = NOW,
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id
+        )
+        // when, then
+        val exception = assertThrows<ScheduleIllegalArgumentException> {
+            scheduleEventService.createSchedule(request)
+        }
+        assertThat(exception).hasMessage(ScheduleExceptionCode.ILLEGAL_CONTENT_ID.message)
+    }
+
+    @DisplayName("다른 커플의 메모를 Schedule로 만들 경우 예외가 발생한다.")
+    @Test
+    fun createSchedule_WithOtherCoupleMemo() {
+        // given
+        val (ownerUser, _, _) = createCouple(userRepository, coupleRepository, "owner", "partner-owner")
+        val memo = contentRepository.save(createContent(ownerUser, ContentType.MEMO))
+        val (otherUser, _, otherCouple) = createCouple(userRepository, coupleRepository, "other", "other2")
+        securityUtilMock.apply {
+            whenever(SecurityUtil.getCurrentUserId()).thenReturn(otherUser.id)
+            whenever(SecurityUtil.getCurrentUserCoupleId()).thenReturn(otherCouple.id)
+        }
+        val request = CreateScheduleRequest(
+            contentId = memo.id,
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = "title",
+            description = "desc",
+            isCompleted = false,
+            startDateTime = NOW,
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id
+        )
+        // when, then
+        val exception = assertThrows<ScheduleAccessDeniedException> {
+            scheduleEventService.createSchedule(request)
+        }
+        assertThat(exception).hasMessage(ScheduleExceptionCode.COUPLE_NOT_MATCHED.message)
+    }
+
+    @DisplayName("Schedule 생성 시 title과 description이 모두 null 또는 blank이면 예외가 발생한다.")
+    @ParameterizedTest
+    @CsvSource(
+        "test title, '      '",
+        "test title, ''",
+        "'        ', test description",
+        "''        , test description",
+        "          ,                 ",
+    )
+    fun createSchedule_WithBlankOrNullTitleDescription(title: String?, description: String?) {
+        // given
+        val (myUser, _, _) = setUpCoupleAndSecurity()
+        val memo = contentRepository.save(createContent(myUser, ContentType.MEMO))
+        val request = CreateScheduleRequest(
+            contentId = memo.id,
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = title,
+            description = description,
+            isCompleted = false,
+            startDateTime = NOW,
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id
+        )
+        // when, then
+        val exception = assertThrows<ScheduleIllegalArgumentException> {
+            scheduleEventService.createSchedule(request)
+        }
+        assertThat(exception).hasMessage(ScheduleExceptionCode.ILLEGAL_CONTENT_DETAIL.message)
+    }
+
+    @DisplayName("endDateTime이 startDateTime보다 이르면 예외 발생")
+    @Test
+    fun createSchedule_WithInvalidDuration() {
+        // given
+        val (myUser, _, _) = setUpCoupleAndSecurity()
+        val memo = contentRepository.save(createContent(myUser, ContentType.MEMO))
+        val request = CreateScheduleRequest(
+            contentId = memo.id,
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = "title",
+            description = "desc",
+            isCompleted = false,
+            startDateTime = NOW,
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
+            endDateTime = NOW.minusDays(1),
+            endTimeZone = DateTimeUtil.UTC_ZONE_ID.id
+        )
+        // when, then
+        val exception = assertThrows<ScheduleIllegalArgumentException> {
+            scheduleEventService.createSchedule(request)
+        }
+        assertThat(exception).hasMessage(ScheduleExceptionCode.ILLEGAL_DURATION.message)
+    }
+}

--- a/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
@@ -154,12 +154,12 @@ class UserControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("프로필을 수정할 때 닉네임은 3~10자여야 한다. (최소 길이 미만)")
+    @DisplayName("프로필을 수정할 때 닉네임은 2~8자여야 한다. (최소 길이 미만)")
     @Test
     fun updateProfile_WithBelowMinLengthNickname() {
         // given
         val request = PutUserProfileRequest(
-            nickname = "ab",  // 2자
+            nickname = "a",  // 1자
             birthday = DateTimeUtil.localNow().toLocalDate(),
         )
 
@@ -175,12 +175,12 @@ class UserControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("프로필을 수정할 때 닉네임은 11자 미만이어야 한다. (최대 길이 초과)")
+    @DisplayName("프로필을 수정할 때 닉네임은 9자 미만이어야 한다. (최대 길이 초과)")
     @Test
     fun updateProfile_WithExceedingMaxLengthNickname() {
         // given
         val request = PutUserProfileRequest(
-            nickname = "12345678901",  // 11자
+            nickname = "123456789",  // 9자
             birthday = DateTimeUtil.localNow().toLocalDate(),
         )
 


### PR DESCRIPTION
## 관련 이슈
- #98 

## 작업한 내용
- 일정 조회 api의 쿼리 수정
- Schedule 생성 api 추가

## PR 포인트
- 일정 조회에서 잘못된 쿼리를 수정했습니다. 이제 시작일 종료일을 같도록 수정하면, 해당 일자의 일정 조회가 가능합니다.
- 기존 존재하던 Memo Type의 Content에서 Schedule을 생성할 수 있도록 생성 api를 추가했습니다. 
  - 한가지 걱정되는 점은 Content -> Schedule일 경우에도 기존의 수정 UI와 동일합니다.
  - 따라서 스케줄을 생성하며 Tag를 포함한 Content의 모든 내용을 수정할 수 있기 때문에 update 메서드를 재활용했습니다.
  - 이부분은 따로 디자인 & 프론트와 회의를 해서 `Schedule 생성 시 내용 수정` 여부에 대한 방향을 확실하게 잡아야 할 것 같습니다.