### PR TITLE
[Feat] 휴일 조회 api 추가

### DIFF
--- a/src/main/kotlin/com/whatever/config/openfeign/KakaoKapiConfig.kt
+++ b/src/main/kotlin/com/whatever/config/openfeign/KakaoKapiConfig.kt
@@ -8,7 +8,6 @@ import com.whatever.global.exception.externalserver.kakao.KakaoServerExceptionCo
 import com.whatever.global.exception.externalserver.kakao.KakaoServerExceptionCode.UNKNOWN
 import com.whatever.global.exception.externalserver.kakao.KakaoServiceUnavailableException
 import com.whatever.global.exception.externalserver.kakao.KakaoUnauthorizedException
-import feign.FeignException
 import feign.Response
 import feign.codec.Encoder
 import feign.codec.ErrorDecoder
@@ -34,9 +33,9 @@ class KakaoKapiConfig {
 }
 
 class KapiErrorDecoder() : ErrorDecoder {
-    override fun decode(methodKey: String?, response: Response?): Exception {
-        if (response == null || response.status() < 400) {
-            return FeignException.errorStatus(methodKey, response)
+    override fun decode(methodKey: String, response: Response): Exception {
+        if (response.status() < 400) {
+            return ErrorDecoder.Default().decode(methodKey, response)
         }
 
         val errorResponse = response.toObject(KapiErrorResponse::class)

--- a/src/main/kotlin/com/whatever/config/openfeign/KakaoKauthConfig.kt
+++ b/src/main/kotlin/com/whatever/config/openfeign/KakaoKauthConfig.kt
@@ -2,7 +2,6 @@ package com.whatever.config.openfeign
 
 import com.whatever.global.exception.externalserver.kakao.KakaoServerException
 import com.whatever.global.exception.externalserver.kakao.KakaoServerExceptionCode
-import feign.FeignException
 import feign.Response
 import feign.codec.Encoder
 import feign.codec.ErrorDecoder
@@ -26,9 +25,9 @@ class KakaoKauthConfig {
 }
 
 class KauthErrorDecoder() : ErrorDecoder {
-    override fun decode(methodKey: String?, response: Response?): Exception {
-        if (response == null || response.status() < 400) {
-            return FeignException.errorStatus(methodKey, response)
+    override fun decode(methodKey: String, response: Response): Exception {
+        if (response.status() < 400) {
+            return ErrorDecoder.Default().decode(methodKey, response)
         }
 
         val errorResponse = response.toObject(KauthErrorResponse::class)

--- a/src/main/kotlin/com/whatever/config/properties/SpecialDayApiProperties.kt
+++ b/src/main/kotlin/com/whatever/config/properties/SpecialDayApiProperties.kt
@@ -1,0 +1,8 @@
+package com.whatever.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("kor.openapi.specialday")
+data class SpecialDayApiProperties (
+    val key: String,
+)

--- a/src/main/kotlin/com/whatever/domain/calendarevent/controller/CalendarController.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/controller/CalendarController.kt
@@ -1,8 +1,11 @@
 package com.whatever.domain.calendarevent.controller
 
 import com.whatever.domain.calendarevent.controller.dto.request.GetCalendarQueryParameter
-import com.whatever.domain.calendarevent.controller.dto.response.*
+import com.whatever.domain.calendarevent.controller.dto.response.CalendarDetailResponse
+import com.whatever.domain.calendarevent.controller.dto.response.CalendarEventsDto
+import com.whatever.domain.calendarevent.controller.dto.response.HolidayDetailListResponse
 import com.whatever.domain.calendarevent.scheduleevent.service.ScheduleEventService
+import com.whatever.domain.calendarevent.specialday.service.SpecialDayService
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
 import io.swagger.v3.oas.annotations.Operation
@@ -10,9 +13,9 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
-import java.time.LocalTime
+import java.time.YearMonth
 
 @Tag(
     name = "Calendar",
@@ -20,7 +23,10 @@ import java.time.LocalTime
 )
 @RestController
 @RequestMapping("/v1/calendar")
-class CalendarController(private val scheduleEventService: ScheduleEventService) {
+class CalendarController(
+    private val scheduleEventService: ScheduleEventService,
+    private val specialDayService: SpecialDayService
+) {
 
     @Operation(
         summary = "캘린더 조회",
@@ -39,27 +45,14 @@ class CalendarController(private val scheduleEventService: ScheduleEventService)
     }
 
     @Operation(
-        summary = "더미 휴일 조회",
-        description = "캘린더에 기본으로 표시되어야하는 특별한 날을 반환합니다.",
+        summary = "휴일 조회",
+        description = "캘린더에 기본으로 표시되어야하는 특별한 날 중 휴일을 반환합니다.",
     )
     @GetMapping("/holidays")
-    fun getHolidays(): CaramelApiResponse<HolidayDetailListResponse> {
-
-        // TODO(준용): 구현 필요
-        val contentList = listOf(
-            HolidayDetailDto(
-                id = 1,
-                type = "SOLAR_TERM",
-                date = LocalDate.parse("2025-12-22"),
-                name = "동지"
-            ),
-            HolidayDetailDto(
-                id = 4,
-                type = "HOLIDAY",
-                date = LocalDate.parse("2025-12-25"),
-                name = "성탄절"
-            )
-        )
-        return HolidayDetailListResponse(contentList).succeed()
+    fun getHolidays(
+        @RequestParam("yearMonth") yearMonth: YearMonth,
+    ): CaramelApiResponse<HolidayDetailListResponse> {
+        val response = specialDayService.getHolidays(yearMonth)
+        return response.succeed()
     }
 }

--- a/src/main/kotlin/com/whatever/domain/calendarevent/controller/dto/response/HolidayInfoResponse.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/controller/dto/response/HolidayInfoResponse.kt
@@ -1,5 +1,7 @@
 package com.whatever.domain.calendarevent.controller.dto.response
 
+import com.whatever.domain.calendarevent.specialday.model.SpecialDay
+import com.whatever.domain.calendarevent.specialday.model.SpecialDayType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -14,12 +16,30 @@ data class HolidayDetailDto(
     @Schema(description = "휴일 id", example = "1")
     val id: Long,
 
-    @Schema(description = "휴일 타입 (예: SOLAR_TERM, HOLIDAY)", example = "SOLAR_TERM")
-    val type: String,
+    @Schema(description = "휴일 타입 (예: HOLI)", example = "HOLI")
+    val type: SpecialDayType,
 
     @Schema(description = "휴일 날짜 (yyyy-MM-dd)", example = "2025-12-22")
     val date: LocalDate,
 
     @Schema(description = "휴일 이름")
-    val name: String
-)
+    val name: String,
+
+    @Schema(description = "공휴일 여부")
+    val isHoliday: Boolean,
+) {
+    companion object {
+        fun from(holiday: SpecialDay): HolidayDetailDto? {
+            if (holiday.type != SpecialDayType.HOLI) {
+                return null
+            }
+            return HolidayDetailDto(
+                id = holiday.id,
+                type = holiday.type,
+                date = holiday.locDate,
+                name = holiday.dateName,
+                isHoliday = holiday.isHoliday,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/SpecialDayApiFeignClient.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/SpecialDayApiFeignClient.kt
@@ -1,0 +1,20 @@
+package com.whatever.domain.calendarevent.specialday.client
+
+import com.whatever.domain.calendarevent.specialday.client.dto.request.HolidayInfoRequestParams
+import com.whatever.domain.calendarevent.specialday.client.dto.response.HolidayApiResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.cloud.openfeign.SpringQueryMap
+import org.springframework.web.bind.annotation.GetMapping
+
+@FeignClient(
+    name = "SpecialDayClient",
+    url = "http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService",
+)
+interface SpecialDayApiFeignClient {
+    @GetMapping(
+        path = ["/getHoliDeInfo"],
+    )
+    fun getHolidayInfo(
+        @SpringQueryMap queryParams: HolidayInfoRequestParams,
+    ): HolidayApiResponse
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/dto/request/HolidayInfoRequestParams.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/dto/request/HolidayInfoRequestParams.kt
@@ -1,0 +1,25 @@
+package com.whatever.domain.calendarevent.specialday.client.dto.request
+
+import java.time.YearMonth
+
+data class HolidayInfoRequestParams(
+    val solYear: Int,
+    val solMonth: String,
+    val ServiceKey: String,
+    val numOfRows: Int = 100
+) {
+    val _type: String = "json"
+
+    companion object {
+        fun fromYearMonth(
+            yearMonth: YearMonth,
+            serviceKey: String,
+        ): HolidayInfoRequestParams {
+            return HolidayInfoRequestParams(
+                solYear = yearMonth.year,
+                solMonth = String.format("%02d", yearMonth.monthValue),
+                ServiceKey = serviceKey,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/dto/response/HolidayApiResponse.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/dto/response/HolidayApiResponse.kt
@@ -1,0 +1,63 @@
+package com.whatever.domain.calendarevent.specialday.client.dto.response
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import java.io.IOException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+data class HolidayApiResponse(
+    val response: HolidayResponse?,
+)
+
+data class HolidayResponse(
+    val header: HolidayHeader,
+    val body: HolidayBody,
+)
+
+data class HolidayHeader(
+    val resultCode: String,
+    val resultMsg: String,
+)
+
+data class HolidayBody(
+    val items: HolidayItemsContainer,
+    val numOfRows: Int,
+    val pageNo: Int,
+    val totalCount: Int,
+)
+
+data class HolidayItemsContainer(
+    val item: List<HolidayItem> = arrayListOf(),
+)
+
+data class HolidayItem(
+    val dateKind: String,  // ex) "01"
+    val dateName: String,  // ex) "어린이날"
+    val isHoliday: String,  // ex) "Y" or "N"
+    @JsonDeserialize(using = BasicIsoDateDeserializer::class)
+    val locdate: LocalDate,  // ex) 20250505 (YYYYMMDD format)
+    val seq: Int,  // ex) 1
+)
+
+private class BasicIsoDateDeserializer : JsonDeserializer<LocalDate>() {
+    companion object {
+        private val FORMATTER = DateTimeFormatter.BASIC_ISO_DATE
+    }
+
+    @Throws(IOException::class)
+    override fun deserialize(parser: JsonParser, context: DeserializationContext): LocalDate? {
+        if (parser.text.isNullOrBlank()) {
+            return null
+        }
+
+        return try {
+            LocalDate.parse(parser.text, FORMATTER)
+        } catch (e: DateTimeParseException) {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/dto/response/HolidayApiResponse.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/client/dto/response/HolidayApiResponse.kt
@@ -1,14 +1,12 @@
 package com.whatever.domain.calendarevent.specialday.client.dto.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
-import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.IOException
 import java.time.LocalDate
@@ -38,6 +36,7 @@ data class HolidayBody(
 )
 
 data class HolidayItemsContainer(
+    @JsonFormat(with = [JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY])
     val item: List<HolidayItem> = arrayListOf(),
 )
 
@@ -47,8 +46,12 @@ data class HolidayItem(
     val isHoliday: String,  // ex) "Y" or "N"
     @JsonDeserialize(using = BasicIsoDateDeserializer::class)
     val locdate: LocalDate,  // ex) 20250505 (YYYYMMDD format)
+    val remarks: String? = null,
     val seq: Int,  // ex) 1
-)
+) {
+    val isHolidayBoolean: Boolean
+        get() = isHoliday == "Y"
+}
 
 private class BasicIsoDateDeserializer : StdDeserializer<LocalDate>(LocalDate::class.java) {
     companion object {

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDay.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDay.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 
 @Entity
 @Table(
-    uniqueConstraints = [UniqueConstraint(columnNames = ["date", "date_name"])]
+    uniqueConstraints = [UniqueConstraint(columnNames = ["loc_date", "date_name"])]
 )
 class SpecialDay(
     @Id
@@ -23,10 +23,10 @@ class SpecialDay(
 
     @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = false)
-    val category: SpecialDayType,
+    val type: SpecialDayType,
 
     @Column(nullable = false)
-    var date: LocalDate,
+    var locDate: LocalDate,
 
     @Column(length = 100, nullable = false)
     var dateName: String,  // ex: "삼일절", "춘분"

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDay.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDay.kt
@@ -1,0 +1,39 @@
+package com.whatever.domain.calendarevent.specialday.model
+
+import com.whatever.domain.base.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.LocalDate
+
+@Entity
+@Table(
+    uniqueConstraints = [UniqueConstraint(columnNames = ["date", "date_name"])]
+)
+class SpecialDay(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    val category: SpecialDayType,
+
+    @Column(nullable = false)
+    var date: LocalDate,
+
+    @Column(length = 100, nullable = false)
+    var dateName: String,  // ex: "삼일절", "춘분"
+
+    @Column(nullable = false)
+    var isHoliday: Boolean,  // 공공기관 휴일 여부
+
+    @Column(nullable = false)
+    var sequence: Int,  // 월 내 순번
+) : BaseEntity()

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDayType.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDayType.kt
@@ -1,0 +1,6 @@
+package com.whatever.domain.calendarevent.specialday.model
+
+enum class SpecialDayType {
+    HOLI,
+    REST,
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDayType.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/model/SpecialDayType.kt
@@ -2,5 +2,4 @@ package com.whatever.domain.calendarevent.specialday.model
 
 enum class SpecialDayType {
     HOLI,
-    REST,
 }

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/repository/SpecialDayRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/repository/SpecialDayRepository.kt
@@ -1,7 +1,26 @@
 package com.whatever.domain.calendarevent.specialday.repository
 
 import com.whatever.domain.calendarevent.specialday.model.SpecialDay
+import com.whatever.domain.calendarevent.specialday.model.SpecialDayType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDate
 
 interface SpecialDayRepository : JpaRepository<SpecialDay, Long> {
+
+    @Query("""
+        select spd
+        from SpecialDay spd
+        where spd.locDate between :startDate and :endDate
+          and spd.type = :type
+          and spd.isHoliday = :isHoliday
+          and spd.isDeleted = false
+        order by spd.locDate
+    """)
+    fun findAllByTypeAndBetweenStartDateAndEndDate(
+        type: SpecialDayType,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        isHoliday: Boolean = true,
+    ): List<SpecialDay>
 }

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/repository/SpecialDayRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/repository/SpecialDayRepository.kt
@@ -1,0 +1,7 @@
+package com.whatever.domain.calendarevent.specialday.repository
+
+import com.whatever.domain.calendarevent.specialday.model.SpecialDay
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SpecialDayRepository : JpaRepository<SpecialDay, Long> {
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayService.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayService.kt
@@ -4,7 +4,7 @@ import com.whatever.config.properties.SpecialDayApiProperties
 import com.whatever.domain.calendarevent.specialday.client.SpecialDayApiFeignClient
 import com.whatever.domain.calendarevent.specialday.client.dto.request.HolidayInfoRequestParams
 import com.whatever.domain.calendarevent.specialday.client.dto.response.HolidayApiResponse
-import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode
+import com.whatever.domain.calendarevent.specialday.repository.SpecialDayRepository
 import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.EMPTY_HEADER
 import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.FAILED_RESPONSE_CODE
 import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.RESPONSE_TYPE_UNMATCHED
@@ -21,6 +21,7 @@ private val logger = KotlinLogging.logger {  }
 class SpecialDayService(
     private val apiProperties: SpecialDayApiProperties,
     private val specialDayFeignClient: SpecialDayApiFeignClient,
+    private val specialDayRepository: SpecialDayRepository,
 ) {
     companion object {
         private const val HOLIDAY_INFO_SUCCESS_CODE = "00"

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayService.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayService.kt
@@ -1,9 +1,12 @@
 package com.whatever.domain.calendarevent.specialday.service
 
 import com.whatever.config.properties.SpecialDayApiProperties
+import com.whatever.domain.calendarevent.controller.dto.response.HolidayDetailDto
+import com.whatever.domain.calendarevent.controller.dto.response.HolidayDetailListResponse
 import com.whatever.domain.calendarevent.specialday.client.SpecialDayApiFeignClient
 import com.whatever.domain.calendarevent.specialday.client.dto.request.HolidayInfoRequestParams
 import com.whatever.domain.calendarevent.specialday.client.dto.response.HolidayApiResponse
+import com.whatever.domain.calendarevent.specialday.model.SpecialDayType
 import com.whatever.domain.calendarevent.specialday.repository.SpecialDayRepository
 import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.EMPTY_HEADER
 import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.FAILED_RESPONSE_CODE
@@ -25,6 +28,19 @@ class SpecialDayService(
 ) {
     companion object {
         private const val HOLIDAY_INFO_SUCCESS_CODE = "00"
+    }
+
+    fun getHolidays(yearMonth: YearMonth): HolidayDetailListResponse {
+        val startDate = yearMonth.atDay(1)
+        val endDate = yearMonth.atEndOfMonth()
+        val holidays = specialDayRepository.findAllByTypeAndBetweenStartDateAndEndDate(
+            SpecialDayType.HOLI,
+            startDate,
+            endDate,
+        )
+
+        val holidayDetailDtos = holidays.mapNotNull { HolidayDetailDto.from(it) }
+        return HolidayDetailListResponse(holidayList = holidayDetailDtos)
     }
 
     private fun getHolidayInfo(yearMonth: YearMonth): HolidayApiResponse {

--- a/src/main/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayService.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayService.kt
@@ -1,0 +1,66 @@
+package com.whatever.domain.calendarevent.specialday.service
+
+import com.whatever.config.properties.SpecialDayApiProperties
+import com.whatever.domain.calendarevent.specialday.client.SpecialDayApiFeignClient
+import com.whatever.domain.calendarevent.specialday.client.dto.request.HolidayInfoRequestParams
+import com.whatever.domain.calendarevent.specialday.client.dto.response.HolidayApiResponse
+import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode
+import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.EMPTY_HEADER
+import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.FAILED_RESPONSE_CODE
+import com.whatever.global.exception.externalserver.specialday.SpecialDayApiExceptionCode.RESPONSE_TYPE_UNMATCHED
+import com.whatever.global.exception.externalserver.specialday.SpecialDayDecodeException
+import com.whatever.global.exception.externalserver.specialday.SpecialDayFailedOperationException
+import feign.codec.DecodeException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+import java.time.YearMonth
+
+private val logger = KotlinLogging.logger {  }
+
+@Service
+class SpecialDayService(
+    private val apiProperties: SpecialDayApiProperties,
+    private val specialDayFeignClient: SpecialDayApiFeignClient,
+) {
+    companion object {
+        private const val HOLIDAY_INFO_SUCCESS_CODE = "00"
+    }
+
+    private fun getHolidayInfo(yearMonth: YearMonth): HolidayApiResponse {
+        val req = HolidayInfoRequestParams.fromYearMonth(
+            yearMonth = yearMonth,
+            serviceKey = apiProperties.key,
+        )
+
+        return runCatching {
+            specialDayFeignClient.getHolidayInfo(req).apply {
+                val header = response?.header
+                    ?: throw SpecialDayDecodeException(errorCode = EMPTY_HEADER)
+
+                if (header.resultCode != HOLIDAY_INFO_SUCCESS_CODE) {
+                    throw SpecialDayFailedOperationException(
+                        errorCode = FAILED_RESPONSE_CODE,
+                        resultCode = header.resultCode,
+                        resultMsg = header.resultMsg,
+                    )
+                }
+            }
+        }.onFailure { e ->
+            when (e) {
+                is SpecialDayFailedOperationException -> {
+                    logger.error(e) { "getHolidayInfo failed. SpecialDayApi returned error. Code: ${e.resultCode}, Message: ${e.resultMsg}" }
+                }
+                is SpecialDayDecodeException -> {
+                    logger.error(e) { "getHolidayInfo failed due to internal decoding logic." }
+                }
+                is DecodeException -> {
+                    logger.error(e) { "getHolidayInfo failed due to Feign decoding error." }
+                    throw SpecialDayDecodeException(errorCode = RESPONSE_TYPE_UNMATCHED)
+                }
+                else -> {
+                    logger.error(e) { "getHolidayInfo failed due to unexpected exception." }
+                }
+            }
+        }.getOrThrow()
+    }
+}

--- a/src/main/kotlin/com/whatever/global/exception/externalserver/specialday/SpecialDayApiException.kt
+++ b/src/main/kotlin/com/whatever/global/exception/externalserver/specialday/SpecialDayApiException.kt
@@ -1,0 +1,20 @@
+package com.whatever.global.exception.externalserver.specialday
+
+import com.whatever.global.exception.externalserver.ExternalServerException
+
+open class SpecialDayApiException(
+    errorCode: SpecialDayApiExceptionCode,
+    detailMessage: String? = null,
+) : ExternalServerException(errorCode, detailMessage)
+
+class SpecialDayDecodeException(
+    errorCode: SpecialDayApiExceptionCode,
+    detailMessage: String? = null,
+) : SpecialDayApiException(errorCode, detailMessage)
+
+class SpecialDayFailedOperationException(
+    errorCode: SpecialDayApiExceptionCode,
+    detailMessage: String? = null,
+    val resultCode: String? = null,
+    val resultMsg: String? = null,
+) : SpecialDayApiException(errorCode, detailMessage)

--- a/src/main/kotlin/com/whatever/global/exception/externalserver/specialday/SpecialDayApiExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/exception/externalserver/specialday/SpecialDayApiExceptionCode.kt
@@ -1,0 +1,19 @@
+package com.whatever.global.exception.externalserver.specialday
+
+import com.whatever.global.exception.externalserver.ExternalServerExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class SpecialDayApiExceptionCode(
+    val sequence: String,
+    override val message: String,
+    override val status: HttpStatus = HttpStatus.BAD_REQUEST,
+) : ExternalServerExceptionCode {
+    UNKNOWN("000", "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
+    EMPTY_HEADER("001", "확인할 수 없는 공휴일 정보 응답입니다."),
+    FAILED_RESPONSE_CODE("002", "공휴일 정보 요청에 실패했습니다."),
+    RESPONSE_TYPE_UNMATCHED("003", "알 수 없는 응답 타입입니다."),
+    ;
+
+    override val code: String
+        get() = "SDA$sequence"
+}

--- a/src/main/kotlin/com/whatever/global/exception/externalserver/specialday/SpecialDayApiExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/global/exception/externalserver/specialday/SpecialDayApiExceptionCode.kt
@@ -8,10 +8,10 @@ enum class SpecialDayApiExceptionCode(
     override val message: String,
     override val status: HttpStatus = HttpStatus.BAD_REQUEST,
 ) : ExternalServerExceptionCode {
-    UNKNOWN("000", "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."),
-    EMPTY_HEADER("001", "확인할 수 없는 공휴일 정보 응답입니다."),
-    FAILED_RESPONSE_CODE("002", "공휴일 정보 요청에 실패했습니다."),
-    RESPONSE_TYPE_UNMATCHED("003", "알 수 없는 응답 타입입니다."),
+    UNKNOWN("000", "알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    EMPTY_HEADER("001", "확인할 수 없는 공휴일 정보 응답입니다.", HttpStatus.BAD_GATEWAY),
+    FAILED_RESPONSE_CODE("002", "공휴일 정보 요청에 실패했습니다.", HttpStatus.BAD_GATEWAY),
+    RESPONSE_TYPE_UNMATCHED("003", "알 수 없는 응답 타입입니다.", HttpStatus.BAD_GATEWAY),
     ;
 
     override val code: String

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -51,3 +51,7 @@ jwt:
   access-expiration-sec: ${ACCESS_EXPIRATION_SEC}
   refresh-expiration-sec: ${REFRESH_EXPIRATION_SEC}
   issuer: Caramel
+kor:  # Kor Open Api Key
+  openapi:
+    specialday:
+      key: ${OPENAPI_SPECIALDAY_KEY}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,6 +73,10 @@ management:
       base-path: ${ACTUATOR_BASE_PATH}
   server:
     port: ${ACTUATOR_BASE_PORT}
+kor:  # Kor Open Api Key
+  openapi:
+    specialday:
+      key: ${OPENAPI_SPECIALDAY_KEY}
 ---
 # Production
 spring:

--- a/src/test/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayServiceTest.kt
@@ -1,0 +1,14 @@
+package com.whatever.domain.calendarevent.specialday.service
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles
+@SpringBootTest
+class SpecialDayServiceTest {
+
+    @Autowired
+    private lateinit var specialDayService: SpecialDayService
+
+}

--- a/src/test/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/specialday/service/SpecialDayServiceTest.kt
@@ -1,14 +1,68 @@
 package com.whatever.domain.calendarevent.specialday.service
 
+import com.whatever.domain.calendarevent.specialday.model.SpecialDay
+import com.whatever.domain.calendarevent.specialday.model.SpecialDayType
+import com.whatever.domain.calendarevent.specialday.repository.SpecialDayRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.YearMonth
+import kotlin.test.Test
 
-@ActiveProfiles
+@ActiveProfiles("test")
 @SpringBootTest
-class SpecialDayServiceTest {
+@Transactional
+class SpecialDayServiceTest @Autowired constructor(
+    private val specialDayService: SpecialDayService,
+    private val specialDayRepository: SpecialDayRepository,
+) {
 
-    @Autowired
-    private lateinit var specialDayService: SpecialDayService
+    @DisplayName("휴일 조회 시 해당 월에 존재하는 휴일이 list 형대로 반환된다.")
+    @Test
+    fun getHolidays() {
+        // given
+        val currentYearMonth = YearMonth.of(2025, 1)
+        val currentLocalDate = currentYearMonth.atEndOfMonth()
+        val holidays = makeTestHoliday(
+            count = currentLocalDate.dayOfMonth,  // 1월에만 휴일 설정
+            startYear = currentYearMonth.year,
+        )
+        specialDayRepository.saveAll(holidays)
+
+        // when
+        val resultWithHolidays = specialDayService.getHolidays(currentYearMonth)
+        val resultWithoutHoliday = specialDayService.getHolidays(currentYearMonth.plusMonths(2))
+
+        // then
+        assertThat(resultWithHolidays.holidayList).hasSize(currentLocalDate.dayOfMonth)
+        assertThat(resultWithoutHoliday.holidayList).isEmpty()
+    }
+
+    private fun makeTestHoliday(
+        count: Int,
+        startYear: Int,
+        type: SpecialDayType = SpecialDayType.HOLI,
+        setOnlyRestHoliday: Boolean = true,
+    ): List<SpecialDay> {
+        val holidays = mutableListOf<SpecialDay>()
+        var currentDate = LocalDate.of(startYear, 1, 1)
+        repeat(count) { idx ->
+            val holiday = SpecialDay(
+                type = type,
+                locDate = currentDate,
+                dateName = "Test Holiday ${idx} ($startYear)",
+                isHoliday = (setOnlyRestHoliday) || (idx % 2 == 0),
+                sequence = 1,
+            )
+            holidays.add(holiday)
+            currentDate = currentDate.plusDays(1)
+        }
+
+        return holidays
+    }
 
 }


### PR DESCRIPTION
## 관련 이슈
- #86 

## 작업한 내용
- 특일 정보 수신을 위한 FeignClient 추가
- 특일 Entity 생성
- 특일 조회 api 생성

## PR 포인트
- 특일 중 국경일+공휴일 정보만 고려했습니다.
- 아래 조건에 따라 주기적 동기화 & 캐싱이 필요하겠지만, 다른 기능이 우선이라고 판단하여 후순위로 작업해두겠습니다
  - 데이터 업데이트는 각 오퍼레이션 별로 연 1회 진행.(1 년치 데이터 일괄 업데이트).
  - 특일정보의 경우 6~8월 경 과학기술정보통신부에서 월력요항 정보를 공식적으로 발표한 이후에 차차년도 데이터를 먼저 업데이트.(현재연도 기준 +2년).
  - 그 외 기념일, 24 절기, 잡은 11 경 업데이트.
  - 추가로 임시공휴일 등 갑작스럽게 발생하는 데이터가 생길 경우 데이터는 바로 업데이트(최대 1 일 이내), 대체공휴일이 추가로 지정되는 경우 대통령령이 공식적으로 시행된 이후에 업데이트.