### PR TITLE
[Feat] 커플 나가기 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 
     // Kotlin 플러그인
-    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.9.25'
-    id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.25'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.20'
+    id 'org.jetbrains.kotlin.plugin.spring' version '2.1.20'
+    id 'org.jetbrains.kotlin.plugin.jpa' version '2.1.20'
 }
 
 ext {
@@ -89,7 +89,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:5.4.0"
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
+    testImplementation 'org.awaitility:awaitility-kotlin:4.3.0'
 }
 
 kotlin {

--- a/src/main/kotlin/com/whatever/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/whatever/config/AsyncConfig.kt
@@ -1,0 +1,23 @@
+package com.whatever.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean(name = ["taskExecutor"])
+    fun taskExecutor(): TaskExecutor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 10
+        executor.queueCapacity = 50
+        executor.maxPoolSize = 30
+        executor.setThreadNamePrefix("async-task-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/com/whatever/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/whatever/config/AsyncConfig.kt
@@ -1,17 +1,18 @@
 package com.whatever.config
 
-import org.springframework.context.annotation.Bean
+import com.whatever.global.exception.CaramelAsyncExceptionHandler
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
 
 
 @Configuration
 @EnableAsync
-class AsyncConfig {
-    @Bean(name = ["taskExecutor"])
-    fun taskExecutor(): TaskExecutor {
+class AsyncConfig : AsyncConfigurer {
+    override fun getAsyncExecutor(): Executor {
         val executor = ThreadPoolTaskExecutor()
         executor.corePoolSize = 10
         executor.queueCapacity = 50
@@ -19,5 +20,9 @@ class AsyncConfig {
         executor.setThreadNamePrefix("async-task-")
         executor.initialize()
         return executor
+    }
+
+    override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler {
+        return CaramelAsyncExceptionHandler()
     }
 }

--- a/src/main/kotlin/com/whatever/domain/balancegame/repository/UserChoiceOptionRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/balancegame/repository/UserChoiceOptionRepository.kt
@@ -2,6 +2,8 @@ package com.whatever.domain.balancegame.repository
 
 import com.whatever.domain.balancegame.model.UserChoiceOption
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
 interface UserChoiceOptionRepository : JpaRepository<UserChoiceOption, Long> {
     fun findByBalanceGame_IdAndUser_IdInAndIsDeleted(
@@ -9,4 +11,13 @@ interface UserChoiceOptionRepository : JpaRepository<UserChoiceOption, Long> {
         userIds: List<Long>,
         isDeleted: Boolean = false,
     ): List<UserChoiceOption>
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+        update UserChoiceOption uco
+        set uco.isDeleted = true
+        where uco.user.id = :userId
+            and uco.isDeleted = false
+    """)
+    fun softDeleteAllByUserIdInBulk(userId: Long): Int
 }

--- a/src/main/kotlin/com/whatever/domain/balancegame/service/event/UserChoiceOptionCleanupService.kt
+++ b/src/main/kotlin/com/whatever/domain/balancegame/service/event/UserChoiceOptionCleanupService.kt
@@ -1,0 +1,16 @@
+package com.whatever.domain.balancegame.service.event
+
+import com.whatever.domain.balancegame.repository.UserChoiceOptionRepository
+import com.whatever.domain.base.AbstractEntityCleanupService
+import com.whatever.domain.content.model.Content
+import org.springframework.stereotype.Service
+
+@Service
+class UserChoiceOptionCleanupService(
+    private val userChoiceOptionRepository: UserChoiceOptionRepository,
+) : AbstractEntityCleanupService<Content>() {
+
+    override fun runCleanup(userId: Long): Int {
+        return userChoiceOptionRepository.softDeleteAllByUserIdInBulk(userId)
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/balancegame/service/event/UserChoiceOptionEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/balancegame/service/event/UserChoiceOptionEventListener.kt
@@ -1,0 +1,28 @@
+package com.whatever.domain.balancegame.service.event
+
+import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class UserChoiceOptionEventListener(
+    private val userChoiceOptionCleanupService: UserChoiceOptionCleanupService
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    fun deleteAllContent(event: CoupleMemberLeaveEvent) {
+        userChoiceOptionCleanupService.cleanupEntity(
+            userId = event.userId,
+            entityName = ENTITY_NAME
+        )
+    }
+
+    companion object {
+        const val ENTITY_NAME = "UserChoiceOption"
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/base/AbstractEntityCleanupService.kt
+++ b/src/main/kotlin/com/whatever/domain/base/AbstractEntityCleanupService.kt
@@ -1,0 +1,46 @@
+package com.whatever.domain.base
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.dao.DataAccessException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Recover
+import org.springframework.retry.annotation.Retryable
+import org.springframework.retry.support.RetrySynchronizationManager
+import org.springframework.transaction.annotation.Transactional
+
+private val logger = KotlinLogging.logger {  }
+
+abstract class AbstractEntityCleanupService<E: BaseEntity> {
+
+    /**
+     * 해당 도메인 entity를 모두 Soft Delete하고, 영향을 받은 row를 반환하는 함수
+     * @param userId 삭제를 진행할 entity의 소유자
+     * @return 삭제에 영향을 받은 row 수
+     */
+    protected abstract fun runCleanup(userId: Long): Int
+
+    @Retryable(
+        retryFor = [DataAccessException::class],
+        backoff = Backoff(delay = 100, maxDelay = 300),
+        maxAttempts = 3,
+    )
+    @Transactional
+    open fun cleanupEntity(userId: Long, entityName: String): Int {
+        val effectedRow = runCleanup(userId)
+
+        val attemptCount = RetrySynchronizationManager.getContext()?.retryCount ?: 0
+        logger.info { "[$effectedRow ${entityName}] soft-deleted for userId: $userId on attempt ${attemptCount + 1}" }
+
+        if (attemptCount > 0 && effectedRow > 0) {  // 재시도 후 성공했을 경우에만 로깅 진행
+            logger.warn { "Successfully soft-deleted $entityName for userId: $userId after ${attemptCount + 1} attempts." }
+        }
+
+        return effectedRow
+    }
+
+    @Recover
+    fun recoverCleanupEntity(ex: Throwable, userId: Long, entityName: String): Int {
+        logger.error { "Failed to soft-delete $entityName for userId: $userId after multiple retries." }
+        throw ex
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/repository/ScheduleEventRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/repository/ScheduleEventRepository.kt
@@ -40,7 +40,6 @@ interface ScheduleEventRepository : JpaRepository<ScheduleEvent, Long> {
     """)
     fun findByIdWithContent(scheduleId: Long): ScheduleEvent?
 
-    @Transactional
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query(
         """

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/repository/ScheduleEventRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/repository/ScheduleEventRepository.kt
@@ -2,7 +2,9 @@ package com.whatever.domain.calendarevent.scheduleevent.repository
 
 import com.whatever.domain.calendarevent.scheduleevent.model.ScheduleEvent
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 interface ScheduleEventRepository : JpaRepository<ScheduleEvent, Long> {
@@ -37,5 +39,21 @@ interface ScheduleEventRepository : JpaRepository<ScheduleEvent, Long> {
             and se.isDeleted = false 
     """)
     fun findByIdWithContent(scheduleId: Long): ScheduleEvent?
+
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(
+        """
+        update ScheduleEvent se
+        set se.isDeleted = true
+        where se.id in (
+            select tse.id from ScheduleEvent tse
+                join tse.content c
+            where c.user.id = :userId
+                and tse.isDeleted = false
+        )
+    """
+    )
+    fun softDeleteAllByUserIdInBulk(userId: Long): Int
 
 }

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventCleanupService.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventCleanupService.kt
@@ -1,0 +1,16 @@
+package com.whatever.domain.calendarevent.scheduleevent.service.event
+
+import com.whatever.domain.base.AbstractEntityCleanupService
+import com.whatever.domain.calendarevent.scheduleevent.model.ScheduleEvent
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ScheduleEventCleanupService(
+    private val scheduleEventRepository: ScheduleEventRepository
+) : AbstractEntityCleanupService<ScheduleEvent>() {
+
+    override fun runCleanup(userId: Long): Int {
+        return scheduleEventRepository.softDeleteAllByUserIdInBulk(userId)
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventListener.kt
@@ -1,6 +1,5 @@
 package com.whatever.domain.calendarevent.scheduleevent.service.event
 
-import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
 import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Async
@@ -12,13 +11,18 @@ private val logger = KotlinLogging.logger {  }
 
 @Component
 class ScheduleEventListener(
-    private val schedulerEventRepository: ScheduleEventRepository,
+    private val scheduleEventCleanupService: ScheduleEventCleanupService,
 ) {
-
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async("taskExecutor")
+    @Async
     fun deleteAllSchedule(event: CoupleMemberLeaveEvent) {
-        val effectedRow = schedulerEventRepository.softDeleteAllByUserIdInBulk(event.userId)
-        logger.info { "${effectedRow} delete Schedule" }
+        scheduleEventCleanupService.cleanupEntity(
+            userId = event.userId,
+            entityName = ENTITY_NAME
+        )
+    }
+
+    companion object {
+        const val ENTITY_NAME = "Schedule"
     }
 }

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventListener.kt
@@ -1,0 +1,24 @@
+package com.whatever.domain.calendarevent.scheduleevent.service.event
+
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class ScheduleEventListener(
+    private val schedulerEventRepository: ScheduleEventRepository,
+) {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async("taskExecutor")
+    fun deleteAllSchedule(event: CoupleMemberLeaveEvent) {
+        val effectedRow = schedulerEventRepository.softDeleteAllByUserIdInBulk(event.userId)
+        logger.info { "${effectedRow} delete Schedule" }
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/content/repository/ContentRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/content/repository/ContentRepository.kt
@@ -22,7 +22,6 @@ interface ContentRepository : JpaRepository<Content, Long>, ContentRepositoryCus
     @Query("SELECT c FROM Content c WHERE c.id = :id AND c.type = :type AND c.isDeleted = false")
     fun findContentByIdAndType(id: Long, type: ContentType): Content?
 
-    @Transactional
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
         update Content c

--- a/src/main/kotlin/com/whatever/domain/content/repository/ContentRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/content/repository/ContentRepository.kt
@@ -12,13 +12,25 @@ import com.whatever.domain.content.tag.model.TagContentMapping
 import com.whatever.domain.user.model.User
 import com.whatever.util.CursorUtil
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 interface ContentRepository : JpaRepository<Content, Long>, ContentRepositoryCustom {
 
     @Query("SELECT c FROM Content c WHERE c.id = :id AND c.type = :type AND c.isDeleted = false")
     fun findContentByIdAndType(id: Long, type: ContentType): Content?
+
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+        update Content c
+        set c.isDeleted = true
+        where c.user.id = :userId
+            and c.isDeleted = false
+    """)
+    fun softDeleteAllByUserIdInBulk(userId: Long): Int
 }
 
 interface ContentRepositoryCustom {

--- a/src/main/kotlin/com/whatever/domain/content/service/event/ContentCleanupService.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/event/ContentCleanupService.kt
@@ -1,0 +1,16 @@
+package com.whatever.domain.content.service.event
+
+import com.whatever.domain.base.AbstractEntityCleanupService
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.repository.ContentRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ContentCleanupService(
+    private val contentRepository: ContentRepository
+) : AbstractEntityCleanupService<Content>() {
+
+    override fun runCleanup(userId: Long): Int {
+        return contentRepository.softDeleteAllByUserIdInBulk(userId)
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/content/service/event/ContentEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/event/ContentEventListener.kt
@@ -1,6 +1,5 @@
 package com.whatever.domain.content.service.event
 
-import com.whatever.domain.content.repository.ContentRepository
 import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Async
@@ -12,13 +11,18 @@ private val logger = KotlinLogging.logger {  }
 
 @Component
 class ContentEventListener(
-    private val contentRepository: ContentRepository
+    private val contentCleanupService: ContentCleanupService
 ) {
-
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async("taskExecutor")
+    @Async
     fun deleteAllContent(event: CoupleMemberLeaveEvent) {
-        val effectedRow = contentRepository.softDeleteAllByUserIdInBulk(event.userId)
-        logger.info { "${effectedRow} delete Content" }
+        contentCleanupService.cleanupEntity(
+            userId = event.userId,
+            entityName = ENTITY_NAME
+        )
+    }
+
+    companion object {
+        const val ENTITY_NAME = "Content"
     }
 }

--- a/src/main/kotlin/com/whatever/domain/content/service/event/ContentEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/event/ContentEventListener.kt
@@ -1,0 +1,24 @@
+package com.whatever.domain.content.service.event
+
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class ContentEventListener(
+    private val contentRepository: ContentRepository
+) {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async("taskExecutor")
+    fun deleteAllContent(event: CoupleMemberLeaveEvent) {
+        val effectedRow = contentRepository.softDeleteAllByUserIdInBulk(event.userId)
+        logger.info { "${effectedRow} delete Content" }
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/content/tag/repository/TagContentMappingRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/repository/TagContentMappingRepository.kt
@@ -2,7 +2,9 @@ package com.whatever.domain.content.tag.repository
 
 import com.whatever.domain.content.tag.model.TagContentMapping
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 
 interface TagContentMappingRepository : JpaRepository<TagContentMapping, Long> {
 
@@ -15,4 +17,18 @@ interface TagContentMappingRepository : JpaRepository<TagContentMapping, Long> {
     fun findAllByContentIdWithTag(contentId: Long): List<TagContentMapping>
 
     fun findAllByContent_IdAndIsDeleted(contentId: Long, isDeleted: Boolean = false): List<TagContentMapping>
+
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("""
+        update TagContentMapping tcm
+        set tcm.isDeleted = true
+        where tcm.id in (
+            select ttcm.id from TagContentMapping ttcm
+                join ttcm.content c
+            where c.user.id = :userId
+                and ttcm.isDeleted = false
+        )
+    """)
+    fun softDeleteAllByUserIdInBulk(userId: Long): Int
 }

--- a/src/main/kotlin/com/whatever/domain/content/tag/repository/TagContentMappingRepository.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/repository/TagContentMappingRepository.kt
@@ -18,7 +18,6 @@ interface TagContentMappingRepository : JpaRepository<TagContentMapping, Long> {
 
     fun findAllByContent_IdAndIsDeleted(contentId: Long, isDeleted: Boolean = false): List<TagContentMapping>
 
-    @Transactional
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("""
         update TagContentMapping tcm

--- a/src/main/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingCleanupService.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingCleanupService.kt
@@ -1,0 +1,16 @@
+package com.whatever.domain.content.tag.service.event
+
+import com.whatever.domain.base.AbstractEntityCleanupService
+import com.whatever.domain.content.tag.model.TagContentMapping
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import org.springframework.stereotype.Service
+
+@Service
+class TagContentMappingCleanupService(
+    private val tagContentMappingRepository: TagContentMappingRepository
+) : AbstractEntityCleanupService<TagContentMapping>() {
+
+    override fun runCleanup(userId: Long): Int {
+        return tagContentMappingRepository.softDeleteAllByUserIdInBulk(userId)
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingEventListener.kt
@@ -1,6 +1,5 @@
 package com.whatever.domain.content.tag.service.event
 
-import com.whatever.domain.content.tag.repository.TagContentMappingRepository
 import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.scheduling.annotation.Async
@@ -12,13 +11,18 @@ private val logger = KotlinLogging.logger {  }
 
 @Component
 class TagContentMappingEventListener(
-    private val tagContentMappingRepository: TagContentMappingRepository
+    private val tagContentMappingCleanupService: TagContentMappingCleanupService
 ) {
-
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async("taskExecutor")
+    @Async
     fun deleteAllTagContentMapping(event: CoupleMemberLeaveEvent) {
-        val effectedRow = tagContentMappingRepository.softDeleteAllByUserIdInBulk(event.userId)
-        logger.info { "${effectedRow} delete TagContentMapping" }
+        tagContentMappingCleanupService.cleanupEntity(
+            userId = event.userId,
+            entityName = ENTITY_NAME,
+        )
+    }
+
+    companion object {
+        const val ENTITY_NAME = "TagContentMapping"
     }
 }

--- a/src/main/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingEventListener.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingEventListener.kt
@@ -1,0 +1,24 @@
+package com.whatever.domain.content.tag.service.event
+
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class TagContentMappingEventListener(
+    private val tagContentMappingRepository: TagContentMappingRepository
+) {
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async("taskExecutor")
+    fun deleteAllTagContentMapping(event: CoupleMemberLeaveEvent) {
+        val effectedRow = tagContentMappingRepository.softDeleteAllByUserIdInBulk(event.userId)
+        logger.info { "${effectedRow} delete TagContentMapping" }
+    }
+}

--- a/src/main/kotlin/com/whatever/domain/couple/controller/CoupleController.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/controller/CoupleController.kt
@@ -90,13 +90,12 @@ class CoupleController(
     }
 
     @Operation(
-        summary = "더미 커플 삭제",
-        description = "커플을 삭제하고, 관련 정보를 모두 삭제합니다."
+        summary = "커플 나가기",
+        description = "커플을 나가고, 지금까지 작성한 모든 데이터를 삭제합니다."
     )
-    @DeleteMapping("/{couple-id}")
-    fun deleteCouple(@PathVariable("couple-id") coupleId: Long): CaramelApiResponse<Unit> {
-
-        // TODO(준용): 구현 필요
+    @DeleteMapping("/{couple-id}/members/me")
+    fun leaveCouple(@PathVariable("couple-id") coupleId: Long): CaramelApiResponse<Unit> {
+        coupleService.leaveCouple(coupleId)
         return CaramelApiResponse.succeed()
     }
 }

--- a/src/main/kotlin/com/whatever/domain/couple/exception/CoupleException.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/exception/CoupleException.kt
@@ -21,3 +21,8 @@ class CoupleIllegalArgumentException(
     errorCode: CoupleExceptionCode,
     detailMessage: String? = null
 ) : CoupleException(errorCode, detailMessage)
+
+class CoupleNotFoundException(
+    errorCode: CoupleExceptionCode,
+    detailMessage: String? = null
+) : CoupleException(errorCode, detailMessage)

--- a/src/main/kotlin/com/whatever/domain/couple/exception/CoupleExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/exception/CoupleExceptionCode.kt
@@ -19,6 +19,7 @@ enum class CoupleExceptionCode(
     ILLEGAL_MEMBER_SIZE("008", "커플에는 반드시 두 명의 유저가 있어야 합니다."),
     UPDATE_FAIL("009", "상대방이 수정 중입니다. 잠시 후 재시도 해주세요.", HttpStatus.CONFLICT),
     ILLEGAL_START_DATE("010", "커플 시작일은 오늘 이전이어야 합니다."),
+    ILLEGAL_COUPLE_STATUS("011", "커플의 상태가 올바르지 않습니다."),
     ;
 
     override val code = "COUPLE$sequence"

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -32,18 +32,17 @@ class Couple (
     @Version
     private var version: Long = 0L
 
-    fun addMember(user: User) {
-        if (mutableMembers.size > 1) {
+    fun addMembers(user1: User, user2: User) {
+        if (mutableMembers.isNotEmpty()) {
             throw CoupleIllegalStateException(
                 errorCode = ILLEGAL_MEMBER_SIZE,
                 detailMessage = "커플에는 반드시 두 명의 유저가 있어야 합니다. 현재 등록된 유저 수: ${mutableMembers.size}"
             )
         }
-        mutableMembers.add(user)
-    }
-
-    fun removeMember(user: User) {
-
+        user1.setCouple(this)
+        user2.setCouple(this)
+        mutableMembers.add(user1)
+        mutableMembers.add(user2)
     }
 
     fun updateStartDate(newDate: LocalDate, userZoneId: ZoneId) {

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -1,7 +1,6 @@
 package com.whatever.domain.couple.model
 
 import com.whatever.domain.base.BaseEntity
-import com.whatever.domain.couple.exception.CoupleExceptionCode
 import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_MEMBER_SIZE
 import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_START_DATE
 import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
@@ -33,8 +32,18 @@ class Couple (
     @Version
     private var version: Long = 0L
 
-    fun addUsers(user: User) {
+    fun addMember(user: User) {
+        if (mutableMembers.size > 1) {
+            throw CoupleIllegalStateException(
+                errorCode = ILLEGAL_MEMBER_SIZE,
+                detailMessage = "커플에는 반드시 두 명의 유저가 있어야 합니다. 현재 등록된 유저 수: ${mutableMembers.size}"
+            )
+        }
         mutableMembers.add(user)
+    }
+
+    fun removeMember(user: User) {
+
     }
 
     fun updateStartDate(newDate: LocalDate, userZoneId: ZoneId) {
@@ -48,15 +57,5 @@ class Couple (
 
     fun updateSharedMessage(newMessage: String?) {
         sharedMessage = newMessage.takeUnless { it.isNullOrBlank() }
-    }
-
-    @PreUpdate
-    protected fun validateMemberSize() {
-        if (mutableMembers.size != 2) {
-            throw CoupleIllegalStateException(
-                errorCode = ILLEGAL_MEMBER_SIZE,
-                detailMessage = "커플에는 반드시 두 명의 유저가 있어야 합니다. 현재 등록된 유저 수: ${mutableMembers.size}"
-            )
-        }
     }
 }

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -34,6 +34,12 @@ class Couple (
     private var version: Long = 0L
 
     fun addMembers(user1: User, user2: User) {
+        if (user1.id == user2.id) {
+            throw CoupleIllegalArgumentException(
+                errorCode = ILLEGAL_MEMBER_SIZE,
+
+            )
+        }
         if (mutableMembers.isNotEmpty()) {
             throw CoupleIllegalStateException(
                 errorCode = ILLEGAL_MEMBER_SIZE,

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -1,6 +1,7 @@
 package com.whatever.domain.couple.model
 
 import com.whatever.domain.base.BaseEntity
+import com.whatever.domain.couple.exception.CoupleExceptionCode
 import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_MEMBER_SIZE
 import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_START_DATE
 import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
@@ -54,7 +55,7 @@ class Couple (
 
     fun removeMember(user: User) {
         if (!mutableMembers.removeIf { it.id == user.id }) {
-            throw RuntimeException("커플 멤버가 아님")  // TODO(준용) IAE
+            throw CoupleIllegalArgumentException(errorCode = CoupleExceptionCode.NOT_A_MEMBER)
         }
 
         user.leaveFromCouple()
@@ -66,7 +67,7 @@ class Couple (
 
     fun updateStartDate(newDate: LocalDate, userZoneId: ZoneId) {
         if (status == INACTIVE) {
-            throw RuntimeException()  // TODO ISE
+            throw CoupleIllegalStateException(errorCode = CoupleExceptionCode.ILLEGAL_COUPLE_STATUS)
         }
         val todayInUserZone = DateTimeUtil.zonedNow(userZoneId).toLocalDate()
         if (newDate.isAfter(todayInUserZone)) {
@@ -78,7 +79,7 @@ class Couple (
 
     fun updateSharedMessage(newMessage: String?) {
         if (status == INACTIVE) {
-            throw RuntimeException()  // TODO ISE
+            throw CoupleIllegalStateException(errorCode = CoupleExceptionCode.ILLEGAL_COUPLE_STATUS)
         }
         sharedMessage = newMessage.takeUnless { it.isNullOrBlank() }
     }

--- a/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
@@ -16,7 +16,9 @@ import com.whatever.domain.couple.exception.CoupleExceptionCode.INVITATION_CODE_
 import com.whatever.domain.couple.exception.CoupleExceptionCode.MEMBER_NOT_FOUND
 import com.whatever.domain.couple.exception.CoupleExceptionCode.NOT_A_MEMBER
 import com.whatever.domain.couple.exception.CoupleExceptionCode.UPDATE_FAIL
+import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
 import com.whatever.domain.couple.exception.CoupleIllegalStateException
+import com.whatever.domain.couple.exception.CoupleNotFoundException
 import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.couple.repository.CoupleRepository
 import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
@@ -146,9 +148,9 @@ class CoupleService(
         userId: Long = SecurityUtil.getCurrentUserId(),
     ) {
         val couple = coupleRepository.findByIdWithMembers(coupleId)
-            ?: throw RuntimeException()  // TODO(준용) NFE
+            ?: throw CoupleNotFoundException(errorCode = COUPLE_NOT_FOUND)
         val user = couple.members.find { it.id == userId }
-            ?: throw RuntimeException()  // TODO(준용) IAE
+            ?: throw CoupleIllegalArgumentException(errorCode = NOT_A_MEMBER)
 
         couple.removeMember(user)
         applicationEventPublisher.publishEvent(CoupleMemberLeaveEvent(coupleId, userId))
@@ -254,10 +256,10 @@ class CoupleService(
 
 private fun UserRepository.findUserById(id: Long, exceptionMessage: String? = null): User {
     return findByIdAndNotDeleted(id)
-        ?: throw CoupleException(errorCode = MEMBER_NOT_FOUND, detailMessage = exceptionMessage)
+        ?: throw CoupleIllegalArgumentException(errorCode = MEMBER_NOT_FOUND, detailMessage = exceptionMessage)
 }
 
 private fun CoupleRepository.findCoupleById(id: Long, exceptionMessage: String? = null): Couple {
     return findByIdAndNotDeleted(id)
-        ?: throw CoupleException(errorCode = COUPLE_NOT_FOUND, detailMessage = exceptionMessage)
+        ?: throw CoupleNotFoundException(errorCode = COUPLE_NOT_FOUND, detailMessage = exceptionMessage)
 }

--- a/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
@@ -75,6 +75,11 @@ class CoupleService(
 
         return CoupleBasicResponse.from(updatedCouple)
     }
+    @Recover
+    fun updateSharedMessageRecover(e: OptimisticLockingFailureException, coupleId: Long): CoupleBasicResponse {
+        logger.error { "couple shared message update fail. couple id: ${coupleId}" }
+        throw CoupleIllegalStateException(errorCode = UPDATE_FAIL)
+    }
 
     @Retryable(
         retryFor = [OptimisticLockingFailureException::class],
@@ -103,13 +108,6 @@ class CoupleService(
 
         return CoupleBasicResponse.from(updatedCouple)
     }
-
-    @Recover
-    fun updateSharedMessageRecover(e: OptimisticLockingFailureException, coupleId: Long): CoupleBasicResponse {
-        logger.error { "couple shared message update fail. couple id: ${coupleId}" }
-        throw CoupleIllegalStateException(errorCode = UPDATE_FAIL)
-    }
-
     @Recover
     fun updateStartDateRecover(
         e: OptimisticLockingFailureException,

--- a/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/service/CoupleService.kt
@@ -160,8 +160,7 @@ class CoupleService(
         validateSingleUser(joinerUser)
 
         val savedCouple = coupleRepository.save(Couple())
-        creatorUser.setCouple(savedCouple)
-        joinerUser.setCouple(savedCouple)
+        savedCouple.addMembers(creatorUser, joinerUser)
 
         redisUtil.deleteCoupleInvitationCode(invitationCode, creatorUserId)
 

--- a/src/main/kotlin/com/whatever/domain/couple/service/event/dto/CoupleMemberLeaveEvent.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/service/event/dto/CoupleMemberLeaveEvent.kt
@@ -1,0 +1,6 @@
+package com.whatever.domain.couple.service.event.dto
+
+data class CoupleMemberLeaveEvent(
+    val coupleId: Long,
+    val userId: Long,
+)

--- a/src/main/kotlin/com/whatever/domain/user/exception/UserExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/user/exception/UserExceptionCode.kt
@@ -10,6 +10,7 @@ enum class UserExceptionCode(
 ) : CaramelExceptionCode {
 
     INVALID_NICKNAME_CHARACTER("002", "닉네임은 한글, 영문, 숫자만 사용 가능합니다."),
+    INVALID_USER_STATUS_FOR_COUPLING("003", "커플이 될 수 없는 유저 상태입니다."),
     ALREADY_EXIST_COUPLE("007", "이미 커플에 소속된 유저 입니다."),
     ;
 

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -3,6 +3,7 @@ package com.whatever.domain.user.model
 import com.whatever.domain.base.BaseEntity
 import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.user.exception.UserExceptionCode
+import com.whatever.domain.user.exception.UserExceptionCode.INVALID_USER_STATUS_FOR_COUPLING
 import com.whatever.domain.user.exception.UserIllegalStateException
 import com.whatever.domain.user.model.UserStatus.COUPLED
 import com.whatever.domain.user.model.UserStatus.SINGLE
@@ -47,7 +48,10 @@ class User(
 
     fun setCouple(couple: Couple) {
         if (userStatus != SINGLE) {
-            throw UserIllegalStateException(UserExceptionCode.ALREADY_EXIST_COUPLE)
+            throw UserIllegalStateException(
+                errorCode = INVALID_USER_STATUS_FOR_COUPLING,
+                detailMessage = "Current user status is '${userStatus}'. To be coupled, the user status must be '${SINGLE}'."
+            )
         }
         _couple = couple
         updateUserStatus(COUPLED)

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -48,7 +48,7 @@ class User(
             throw UserIllegalStateException(UserExceptionCode.ALREADY_EXIST_COUPLE)
         }
         _couple = couple
-        couple.addUsers(this)
+        couple.addMember(this)
         updateUserStatus(UserStatus.COUPLED)
     }
 

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -4,6 +4,8 @@ import com.whatever.domain.base.BaseEntity
 import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.user.exception.UserExceptionCode
 import com.whatever.domain.user.exception.UserIllegalStateException
+import com.whatever.domain.user.model.UserStatus.COUPLED
+import com.whatever.domain.user.model.UserStatus.SINGLE
 import jakarta.persistence.*
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
@@ -44,11 +46,16 @@ class User(
     val couple: Couple? get() = _couple
 
     fun setCouple(couple: Couple) {
-        if (_couple != null) {
+        if (userStatus != SINGLE) {
             throw UserIllegalStateException(UserExceptionCode.ALREADY_EXIST_COUPLE)
         }
         _couple = couple
-        updateUserStatus(UserStatus.COUPLED)
+        updateUserStatus(COUPLED)
+    }
+
+    fun leaveFromCouple() {
+        this._couple = null
+        updateUserStatus(SINGLE)
     }
 
     fun updateUserStatus(newStatus: UserStatus) {
@@ -63,6 +70,6 @@ class User(
         this.nickname = nickname
         this.birthDate = birthday
         this.gender = gender
-        this.userStatus = UserStatus.SINGLE
+        this.userStatus = SINGLE
     }
 }

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -48,7 +48,6 @@ class User(
             throw UserIllegalStateException(UserExceptionCode.ALREADY_EXIST_COUPLE)
         }
         _couple = couple
-        couple.addMember(this)
         updateUserStatus(UserStatus.COUPLED)
     }
 

--- a/src/main/kotlin/com/whatever/global/exception/CaramelAsyncExceptionHandler.kt
+++ b/src/main/kotlin/com/whatever/global/exception/CaramelAsyncExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.whatever.global.exception
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
+import java.lang.reflect.Method
+
+private val logger = KotlinLogging.logger {  }
+
+class CaramelAsyncExceptionHandler : AsyncUncaughtExceptionHandler {
+    override fun handleUncaughtException(
+        ex: Throwable,
+        method: Method,
+        vararg params: Any?
+    ) {
+        logger.error(ex) { "Async exception caught from ${method.name}()" }
+    }
+}

--- a/src/test/kotlin/com/whatever/domain/balancegame/service/event/UserChoiceOptionCleanupServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/balancegame/service/event/UserChoiceOptionCleanupServiceTest.kt
@@ -1,0 +1,140 @@
+package com.whatever.domain.balancegame.service.event
+
+import com.whatever.domain.balancegame.model.BalanceGame
+import com.whatever.domain.balancegame.model.BalanceGameOption
+import com.whatever.domain.balancegame.model.UserChoiceOption
+import com.whatever.domain.balancegame.repository.BalanceGameOptionRepository
+import com.whatever.domain.balancegame.repository.BalanceGameRepository
+import com.whatever.domain.balancegame.repository.UserChoiceOptionRepository
+import com.whatever.domain.calendarevent.scheduleevent.service.event.ScheduleEventListener
+import com.whatever.domain.calendarevent.scheduleevent.service.event.createSchedules
+import com.whatever.domain.couple.repository.CoupleRepository
+import com.whatever.domain.couple.service.makeCouple
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.util.DateTimeUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class UserChoiceOptionCleanupServiceTest @Autowired constructor(
+    private val balanceGameRepository: BalanceGameRepository,
+    private val balanceGameOptionRepository: BalanceGameOptionRepository,
+    private val userChoiceOptionRepository: UserChoiceOptionRepository,
+    private val coupleRepository: CoupleRepository,
+    private val userRepository: UserRepository,
+) {
+
+    @Autowired
+    private lateinit var userChoiceOptionCleanupService: UserChoiceOptionCleanupService
+
+    @AfterEach
+    fun tearDown() {
+        userChoiceOptionRepository.deleteAllInBatch()
+        balanceGameOptionRepository.deleteAllInBatch()
+        balanceGameRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("UserChoiceOptionCleanupService.cleanupEntity() 호출 시 특정 사용자의 선택들이 모두 제거된다.")
+    @Test
+    fun cleanupSchedule() {
+        // given
+        val (myUser, partnerUser, _) = makeCouple(userRepository, coupleRepository)
+
+        val gameSize = 50
+        val optionsPerGame = 2
+        val gameWithOptionsList = createBalanceGamesWithOptions(
+            balanceGameRepository = balanceGameRepository,
+            balanceGameOptionRepository = balanceGameOptionRepository,
+            gamesCount = gameSize,
+            optionsPerGame = optionsPerGame
+        )
+        val myChoices = createUserChoiceOption(userChoiceOptionRepository, gameWithOptionsList, myUser)
+        val partnerChoices = createUserChoiceOption(userChoiceOptionRepository, gameWithOptionsList, partnerUser)
+
+        // when
+        val deletedEntityCnt = userChoiceOptionCleanupService.cleanupEntity(
+            userId = myUser.id,
+            entityName = ScheduleEventListener.ENTITY_NAME
+        )
+
+        // then
+        assertThat(deletedEntityCnt).isEqualTo(myChoices.size)
+
+        val remainingChoiceIds = userChoiceOptionRepository.findAll().filter { !it.isDeleted }.map { it.id }
+        assertThat(remainingChoiceIds).containsExactlyInAnyOrderElementsOf(partnerChoices.map { it.id })
+    }
+
+}
+
+fun createUserChoiceOption(
+    userChoiceOptionRepository: UserChoiceOptionRepository,
+    gameWithOptionsList: List<BalanceGame>,
+    user: User,
+): List<UserChoiceOption> {
+    val userChoiceOptions = gameWithOptionsList.map {
+        UserChoiceOption(
+            balanceGame = it,
+            balanceGameOption = it.options.first(),
+            user = user,
+        )
+    }
+    return userChoiceOptionRepository.saveAll(userChoiceOptions)
+}
+
+fun createBalanceGames(
+    balanceGameRepository: BalanceGameRepository,
+    count: Int
+): List<BalanceGame> {
+    if (count <= 0) return emptyList()
+
+    val today = DateTimeUtil.localNow().toLocalDate()
+    val gamesToSave = (1..count).map { i ->
+        BalanceGame(
+            gameDate = today.minusDays(i.toLong()),
+            question = "테스트 질문 $i"
+        )
+    }
+    return balanceGameRepository.saveAll(gamesToSave)
+}
+
+fun createBalanceGameOptions(
+    balanceGameOptionRepository: BalanceGameOptionRepository,
+    balanceGame: BalanceGame,
+    count: Int
+): List<BalanceGameOption> {
+    if (count <= 0) return emptyList()
+
+    val optionsToSave = (1..count).map { i ->
+        BalanceGameOption(
+            optionText = "테스트 옵션 $i",
+            balanceGame = balanceGame
+        )
+    }
+    return balanceGameOptionRepository.saveAll(optionsToSave)
+}
+
+fun createBalanceGamesWithOptions(
+    balanceGameRepository: BalanceGameRepository,
+    balanceGameOptionRepository: BalanceGameOptionRepository,
+    gamesCount: Int,
+    optionsPerGame: Int
+): List<BalanceGame> {
+    val games = createBalanceGames(balanceGameRepository, gamesCount)
+    return games.map {
+        BalanceGame(
+            id = it.id,
+            gameDate = it.gameDate,
+            question = it.question,
+            options = createBalanceGameOptions(balanceGameOptionRepository, it, optionsPerGame)
+        )
+    }
+}

--- a/src/test/kotlin/com/whatever/domain/base/AbstractEntityCleanupServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/base/AbstractEntityCleanupServiceTest.kt
@@ -1,0 +1,104 @@
+package com.whatever.domain.base
+
+import com.whatever.global.exception.GlobalExceptionCode
+import com.whatever.global.exception.common.CaramelException
+import com.whatever.global.exception.common.CaramelExceptionCode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Profile
+import org.springframework.dao.DataAccessException
+import org.springframework.stereotype.Component
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AbstractEntityCleanupServiceTest {
+
+    @MockitoSpyBean
+    private lateinit var cleanupService: FakeEntityCleanupService
+
+    @DisplayName("cleanupEntity()에서 DataAccessException 발생하면 최대 3번까지 재시도한다.")
+    @Test
+    fun cleanupEntity_WithSuccessAfterRetry() {
+        // given
+        whenever(cleanupService.runCleanup(any()))
+            .thenThrow(FakeDataAccessException("first fail"))
+            .thenThrow(FakeDataAccessException("second fail"))
+            .thenReturn(EFFECTED_ROW_COUNT)
+
+        // when
+        cleanupService.cleanupEntity(USER_ID, ENTITY_NAME)
+
+        // then
+        verify(cleanupService, times(3))
+            .cleanupEntity(any(), any())
+        verify(cleanupService, never())
+            .recoverCleanupEntity(any(), any(), any())
+    }
+
+    @DisplayName("cleanupEntity()에서 DataAccessException이 세번 발생하면 복구 메서드에 진입하고 예외 발생한다.")
+    @Test
+    fun cleanupEntity_WithFail() {
+        // given
+        whenever(cleanupService.runCleanup(any()))
+            .thenThrow(FakeDataAccessException("first fail"))
+            .thenThrow(FakeDataAccessException("second fail"))
+            .thenThrow(FakeDataAccessException("third fail"))
+
+        // when
+        val result = assertThrows<FakeDataAccessException> {
+            cleanupService.cleanupEntity(USER_ID, ENTITY_NAME)
+        }
+
+        // then
+        assertThat(result.message).isEqualTo("third fail")
+        verify(cleanupService, times(3))
+            .cleanupEntity(any(), any())
+    }
+
+    @DisplayName("cleanupEntity()에서 DataAccessException 이외의 예외가 발생하면 바로 복구 메서드로 진입하고, 예외가 발생한다.")
+    @Test
+    fun cleanupEntity_WithFailByNonDataAccessException() {
+        // given
+        whenever(cleanupService.runCleanup(any()))
+            .thenThrow(FakeNonRetryException(GlobalExceptionCode.UNKNOWN))
+
+        // when
+        val result = assertThrows<FakeNonRetryException> {
+            cleanupService.cleanupEntity(USER_ID, ENTITY_NAME)
+        }
+
+        // then
+        assertThat(result.errorCode).isEqualTo(GlobalExceptionCode.UNKNOWN)
+        verify(cleanupService, times(1))
+            .cleanupEntity(any(), any())
+    }
+
+    companion object {
+        const val USER_ID = 0L
+        const val ENTITY_NAME = "Fake"
+        const val EFFECTED_ROW_COUNT = 0
+    }
+}
+
+@Profile("test")
+@Component
+class FakeEntityCleanupService : AbstractEntityCleanupService<FakeEntity>() {
+    public override fun runCleanup(userId: Long): Int {
+        // 모킹을 통해 해당 메서드를 제어한다.
+        return 0
+    }
+}
+
+class FakeEntity : BaseEntity()
+class FakeDataAccessException(msg: String) : DataAccessException(msg)
+class FakeNonRetryException(errorCode: CaramelExceptionCode) : CaramelException(errorCode)

--- a/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/ScheduleEventServiceTest.kt
@@ -747,8 +747,7 @@ internal fun createCouple(
             sharedMessage = sharedMessage
         )
     )
-    myUser.setCouple(savedCouple)
-    partnerUser.setCouple(savedCouple)
+    savedCouple.addMembers(myUser, partnerUser)
 
     userRepository.save(myUser)
     userRepository.save(partnerUser)

--- a/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventCleanupServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/service/event/ScheduleEventCleanupServiceTest.kt
@@ -1,0 +1,102 @@
+package com.whatever.domain.calendarevent.scheduleevent.service.event
+
+import com.whatever.domain.calendarevent.scheduleevent.model.ScheduleEvent
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.model.ContentDetail
+import com.whatever.domain.content.model.ContentType
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.couple.repository.CoupleRepository
+import com.whatever.domain.couple.service.makeCouple
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.util.DateTimeUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.*
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ScheduleEventCleanupServiceTest @Autowired constructor(
+    private val scheduleEventCleanupService: ScheduleEventCleanupService,
+    private val coupleRepository: CoupleRepository,
+    private val userRepository: UserRepository,
+    private val scheduleEventRepository: ScheduleEventRepository,
+    private val contentRepository: ContentRepository,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        scheduleEventRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("ScheduleEventCleanupService.cleanupEntity() 호출 시 특정 사용자의 스케줄이 모두 제거된다.")
+    @Test
+    fun cleanupSchedule() {
+        // given
+        val (myUser, partnerUser, _) = makeCouple(userRepository, coupleRepository)
+
+        val myDataSize = 20
+        createSchedules(scheduleEventRepository, contentRepository, myUser, myDataSize)
+        val partnerDataSize = 10
+        val partnerSchedule = createSchedules(scheduleEventRepository, contentRepository, partnerUser, partnerDataSize)
+
+        // when
+        val deletedEntityCnt = scheduleEventCleanupService.cleanupEntity(
+            userId = myUser.id,
+            entityName = ScheduleEventListener.ENTITY_NAME
+        )
+
+        // then
+        assertThat(deletedEntityCnt).isEqualTo(myDataSize)
+
+        val remainingScheduleIds = scheduleEventRepository.findAll().filter { !it.isDeleted }.map { it.id }
+        assertThat(remainingScheduleIds).containsExactlyInAnyOrderElementsOf(partnerSchedule.map { it.id })
+    }
+
+}
+
+fun createSchedules(
+    scheduleEventRepository: ScheduleEventRepository,
+    contentRepository: ContentRepository,
+    user: User,
+    count: Int
+): List<ScheduleEvent> {
+    if (count == 0) return emptyList()
+    val contentsToSave = mutableListOf<Content>()
+    val now = DateTimeUtil.localNow()
+    for (i in 1..count) {
+        val contentDetail = ContentDetail(title = "Test Schedule Title $i", description = "Test Schedule Text $i")
+        contentsToSave.add(
+            Content(
+                user = user,
+                contentDetail = contentDetail,
+                type = ContentType.SCHEDULE
+            )
+        )
+    }
+    val savedContents = contentRepository.saveAll(contentsToSave)
+
+    val schedulesToSave = mutableListOf<ScheduleEvent>()
+    savedContents.forEachIndexed { index, content ->
+        schedulesToSave.add(
+            ScheduleEvent(
+                uid = UUID.randomUUID().toString(),
+                startDateTime = now.plusHours(index.toLong() + 1), // ensure unique times if needed
+                endDateTime = now.plusHours(index.toLong() + 2),
+                startTimeZone = DateTimeUtil.UTC_ZONE_ID,
+                endTimeZone = DateTimeUtil.UTC_ZONE_ID,
+                content = content
+            )
+        )
+    }
+    return scheduleEventRepository.saveAll(schedulesToSave)
+}

--- a/src/test/kotlin/com/whatever/domain/content/service/ContentServicePaginationTest.kt
+++ b/src/test/kotlin/com/whatever/domain/content/service/ContentServicePaginationTest.kt
@@ -98,7 +98,7 @@ class ContentServicePaginationTest @Autowired constructor(
                 // 마지막 페이지라면, 남은 아이템 수만큼 조회되어야 함
                 val expectedLastPageSize = totalItems % pageSize
                 assertThat(response.list).hasSize(expectedLastPageSize)
-                assertThat(response.cursor.next).isNull()
+                assertThat(response.cursor.next as String?).isNull()
             }
 
         } while (currentCursor != null)
@@ -227,8 +227,8 @@ internal fun createCouple(
     myPlatformUserId: String = "me",
     partnerPlatformUserId: String = "partner",
 ): Triple<User, User, Couple> {
-    val myUser = userRepository.save(createUser("my}", myPlatformUserId))
-    val partnerUser = userRepository.save(createUser("partner", partnerPlatformUserId))
+    val myUser = userRepository.save(createUser("my}", myPlatformUserId, UserStatus.SINGLE))
+    val partnerUser = userRepository.save(createUser("partner", partnerPlatformUserId, UserStatus.SINGLE))
 
     val startDate = DateTimeUtil.localNow().toLocalDate()
     val savedCouple = coupleRepository.save(
@@ -237,8 +237,7 @@ internal fun createCouple(
             sharedMessage = "test message for $myPlatformUserId"
         )
     )
-    myUser.setCouple(savedCouple)
-    partnerUser.setCouple(savedCouple)
+    savedCouple.addMembers(myUser, partnerUser)
 
     userRepository.save(myUser)
     userRepository.save(partnerUser)

--- a/src/test/kotlin/com/whatever/domain/content/service/ContentServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/content/service/ContentServiceTest.kt
@@ -41,12 +41,6 @@ class ContentServiceTest @Autowired constructor(
 
     @BeforeEach
     fun setUp() {
-        scheduleEventRepository.deleteAllInBatch()
-        tagContentMappingRepository.deleteAllInBatch()
-        contentRepository.deleteAllInBatch()
-        tagRepository.deleteAllInBatch()
-        userRepository.deleteAllInBatch()
-
         testUser = userRepository.save(
             User(platform = LoginPlatform.KAKAO, platformUserId = "test-user")
         )
@@ -58,6 +52,12 @@ class ContentServiceTest @Autowired constructor(
     @AfterEach
     fun tearDown() {
         securityUtilMock.close()
+
+        scheduleEventRepository.deleteAllInBatch()
+        tagContentMappingRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
+        tagRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
     }
 
     private fun createTestTag(label: String): Tag {

--- a/src/test/kotlin/com/whatever/domain/content/service/event/ContentCleanupServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/content/service/event/ContentCleanupServiceTest.kt
@@ -1,0 +1,81 @@
+package com.whatever.domain.content.service.event
+
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import com.whatever.domain.calendarevent.scheduleevent.service.event.createSchedules
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.model.ContentDetail
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.couple.repository.CoupleRepository
+import com.whatever.domain.couple.service.makeCouple
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class ContentCleanupServiceTest  @Autowired constructor(
+    private val contentCleanupService: ContentCleanupService,
+    private val coupleRepository: CoupleRepository,
+    private val userRepository: UserRepository,
+    private val scheduleEventRepository: ScheduleEventRepository,
+    private val contentRepository: ContentRepository,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        scheduleEventRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("ContentCleanupService.cleanupEntity() 호출 시 특정 사용자의 콘텐츠가 모두 제거된다.")
+    @Test
+    fun cleanupContent() {
+        // given
+        val (myUser, partnerUser, _) = makeCouple(userRepository, coupleRepository)
+
+        val myDataSize = 20
+        val mySchedules = createSchedules(scheduleEventRepository, contentRepository, myUser, myDataSize)  // Schedule, Content(Schedule)
+        val myMemos = createMemos(contentRepository, myUser, myDataSize)  // Content(Memo)
+
+        val partnerDataSize = 10
+        val partnerMemos = createMemos(contentRepository, partnerUser, partnerDataSize)
+
+        // when
+        val deletedEntityCnt = contentCleanupService.cleanupEntity(
+            userId = myUser.id,
+            entityName = ContentEventListener.ENTITY_NAME
+        )
+
+        // then
+        assertThat(deletedEntityCnt).isEqualTo(mySchedules.size + myMemos.size)
+
+        val remainingContentIds = contentRepository.findAll().filter { !it.isDeleted }.map { it.id }
+        assertThat(remainingContentIds).containsExactlyInAnyOrderElementsOf(partnerMemos.map { it.id })
+
+        val remainingScheduleIds = scheduleEventRepository.findAll().filter { !it.isDeleted }.map { it.id }
+        assertThat(remainingScheduleIds).containsExactlyInAnyOrderElementsOf(mySchedules.map { it.id })
+    }
+}
+
+fun createMemos(contentRepository: ContentRepository, user: User, count: Int): List<Content> {
+    if (count == 0) return emptyList()
+    val memosToSave = mutableListOf<Content>()
+    for (i in 1..count) {
+        val contentDetail = ContentDetail(title = "Test Memo Title $i", description = "Test Memo Text $i")
+        memosToSave.add(
+            Content(
+                user = user,
+                contentDetail = contentDetail
+            )
+        )
+    }
+    return contentRepository.saveAll(memosToSave)
+}

--- a/src/test/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingCleanupServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/content/tag/service/event/TagContentMappingCleanupServiceTest.kt
@@ -1,0 +1,102 @@
+package com.whatever.domain.content.tag.service.event
+
+import com.whatever.domain.calendarevent.scheduleevent.service.event.ScheduleEventListener
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.content.service.event.createMemos
+import com.whatever.domain.content.tag.model.Tag
+import com.whatever.domain.content.tag.model.TagContentMapping
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import com.whatever.domain.content.tag.repository.TagRepository
+import com.whatever.domain.couple.repository.CoupleRepository
+import com.whatever.domain.couple.service.makeCouple
+import com.whatever.domain.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TagContentMappingCleanupServiceTest @Autowired constructor(
+    private val tagContentMappingCleanupService: TagContentMappingCleanupService,
+    private val coupleRepository: CoupleRepository,
+    private val userRepository: UserRepository,
+    private val contentRepository: ContentRepository,
+    private val tagContentMappingRepository: TagContentMappingRepository,
+    private val tagRepository: TagRepository,
+) {
+
+    @AfterEach
+    fun tearDown() {
+        tagContentMappingRepository.deleteAllInBatch()
+        tagRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+    }
+
+    @DisplayName("TagContentMappingCleanupService.cleanupEntity() 호출 시 특정 사용자의 TagContentMapping이 모두 제거된다.")
+    @Test
+    fun cleanupTagContentMapping() {
+        // given
+        val (myUser, partnerUser, _) = makeCouple(userRepository, coupleRepository)
+
+        val tagSize = 20
+        val tags = createTags(tagRepository, tagSize)
+
+        val myDataSize = 20
+        val myMemos = createMemos(contentRepository, myUser, myDataSize)
+        val myMappings = createTagContentMappings(tagContentMappingRepository, tags, myMemos)
+
+        val partnerDataSize = 10
+        val partnerMemos = createMemos(contentRepository, partnerUser, partnerDataSize)
+        val partnerMappings = createTagContentMappings(tagContentMappingRepository, tags, partnerMemos)
+
+        // when
+        val deletedEntityCnt = tagContentMappingCleanupService.cleanupEntity(
+            userId = myUser.id,
+            entityName = ScheduleEventListener.ENTITY_NAME
+        )
+
+        // then
+        assertThat(deletedEntityCnt).isEqualTo(myMappings.size)
+
+        val remainingMappingIds = tagContentMappingRepository.findAll().filter { !it.isDeleted }.map { it.id }
+        assertThat(remainingMappingIds).containsExactlyInAnyOrderElementsOf(partnerMappings.map { it.id })
+    }
+}
+
+fun createTags(tagRepository: TagRepository, count: Int): List<Tag> {
+    if (count == 0) return emptyList()
+    val tagsToSave = mutableListOf<Tag>()
+    for (i in 1..count) {
+        tagsToSave.add(Tag(label = "Test Tag $i"))
+    }
+    return tagRepository.saveAll(tagsToSave)
+}
+
+/**
+ * 각 content에 tags를 모두 할당하는 메서드
+ */
+fun createTagContentMappings(
+    tagContentMappingRepository: TagContentMappingRepository,
+    tags: List<Tag>,
+    contents: List<Content>
+): List<TagContentMapping> {
+    if (tags.isEmpty() || contents.isEmpty()) return emptyList()
+    val mappingsToSave = mutableListOf<TagContentMapping>()
+    contents.forEach { content ->
+        val mappings = tags.map {
+            TagContentMapping(
+                tag = it,
+                content = content
+            )
+        }
+        mappingsToSave.addAll(mappings)
+    }
+    return tagContentMappingRepository.saveAll(mappingsToSave)
+}

--- a/src/test/kotlin/com/whatever/domain/couple/model/CoupleTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/model/CoupleTest.kt
@@ -1,0 +1,98 @@
+package com.whatever.domain.couple.model
+
+import com.whatever.domain.couple.exception.CoupleExceptionCode.ILLEGAL_MEMBER_SIZE
+import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
+import com.whatever.domain.couple.exception.CoupleIllegalStateException
+import com.whatever.domain.user.model.LoginPlatform
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.UserStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+
+class CoupleTest {
+
+    @DisplayName("커플에 멤버를 추가할 경우 커플과 유저 양방향으로 등록된다.")
+    @Test
+    fun addMembers() {
+        // given
+        val couple = Couple()
+        val user1 = User(
+            id = 1L,
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test1",
+            userStatus = UserStatus.SINGLE,
+        )
+        val user2 = User(
+            id = 2L,
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test2",
+            userStatus = UserStatus.SINGLE,
+        )
+
+        // when
+        couple.addMembers(user1, user2)
+
+        // then
+        assertThat(couple.members).containsExactlyInAnyOrder(user1, user2)
+        assertThat(couple.status).isEqualTo(CoupleStatus.ACTIVE)
+        assertThat(user1.couple).isNotNull
+        assertThat(user2.couple).isNotNull
+    }
+
+    @DisplayName("커플을 같은 유저만으로 구성할 경우 예외가 발생한다.")
+    @Test
+    fun addMembers_WithSameUser() {
+        // given
+        val couple = Couple()
+        val user = User(
+            id = 1L,
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test1",
+            userStatus = UserStatus.SINGLE,
+        )
+
+        // when
+        val result = assertThrows<CoupleIllegalArgumentException> { couple.addMembers(user, user) }
+
+        // then
+        assertThat(result.errorCode).isEqualTo(ILLEGAL_MEMBER_SIZE)
+    }
+
+    @DisplayName("커플멤버가 구성된 상태에서 추가로 등록을 할 경우 예외가 발생한다.")
+    @Test
+    fun addMembers_WithFullCouple() {
+        // given
+        val couple = Couple()
+        val user1 = User(
+            id = 1L,
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test1",
+            userStatus = UserStatus.SINGLE,
+        )
+        val user2 = User(
+            id = 2L,
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test2",
+            userStatus = UserStatus.SINGLE,
+        )
+        couple.addMembers(user1, user2)
+
+        val user3 = User(
+            id = 3L,
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test3",
+            userStatus = UserStatus.SINGLE,
+        )
+
+        // when
+        val result = assertThrows<CoupleIllegalStateException> { couple.addMembers(user3, user2) }
+
+
+        // then
+        assertThat(result.errorCode).isEqualTo(ILLEGAL_MEMBER_SIZE)
+    }
+
+
+}

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceEventTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceEventTest.kt
@@ -1,0 +1,124 @@
+package com.whatever.domain.couple.service
+
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import com.whatever.domain.content.tag.repository.TagRepository
+import com.whatever.domain.couple.model.Couple
+import com.whatever.domain.couple.model.CoupleStatus.INACTIVE
+import com.whatever.domain.couple.repository.CoupleRepository
+import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.UserStatus.COUPLED
+import com.whatever.domain.user.model.UserStatus.SINGLE
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.global.security.util.SecurityUtil
+import com.whatever.util.findByIdAndNotDeleted
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.event.ApplicationEvents
+import org.springframework.test.context.event.RecordApplicationEvents
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+@RecordApplicationEvents
+class CoupleServiceEventTest @Autowired constructor(
+    private val coupleService: CoupleService,
+    private val userRepository: UserRepository,
+    private val coupleRepository: CoupleRepository,
+    private val tagContentMappingRepository: TagContentMappingRepository,
+    private val tagRepository: TagRepository,
+    private val scheduleEventRepository: ScheduleEventRepository,
+    private val contentRepository: ContentRepository,
+) {
+
+    // autowired 경고가 나오지만 문제 없음
+    @Suppress("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    private lateinit var events: ApplicationEvents
+
+    private lateinit var securityUtilMock: AutoCloseable
+
+    @BeforeEach
+    fun setUp() {
+        securityUtilMock = mockStatic(SecurityUtil::class.java)
+
+        tagContentMappingRepository.deleteAllInBatch()
+        scheduleEventRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+        tagRepository.deleteAllInBatch()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        securityUtilMock.close()
+    }
+
+    @DisplayName("커플 멤버 중 한명이 나갈 경우 커플의 상태를 변경하고 나간 유저의 상태를 SINGLE로 변경한다.")
+    @Test
+    fun leaveCouple() {
+        // given
+        val (myUser, partnerUser, savedCouple) = makeCouple(userRepository, coupleRepository)
+        securityUtilMock.apply {
+            whenever(SecurityUtil.getCurrentUserId()).doReturn(myUser.id)
+        }
+        // when
+        coupleService.leaveCouple(savedCouple.id, myUser.id)
+
+        // then - 커플 나가기 이후 상태 변경 확인
+        val inactiveCouple = coupleRepository.findByIdWithMembers(savedCouple.id)
+        require(inactiveCouple != null)
+        assertThat(inactiveCouple.status).isEqualTo(INACTIVE)
+        assertThat(inactiveCouple.members.map { it.id })
+            .doesNotContain(myUser.id)
+            .containsOnly(partnerUser.id)
+
+        val leavedMyUser = userRepository.findByIdAndNotDeleted(myUser.id)
+        val remainingPartnerUser = userRepository.findByIdAndNotDeleted(partnerUser.id)
+        assertThat(leavedMyUser!!.userStatus).isEqualTo(SINGLE)
+        assertThat(remainingPartnerUser!!.userStatus).isEqualTo(COUPLED)
+
+        val eventPublishCnt = events.stream(CoupleMemberLeaveEvent::class.java).count()
+        assertThat(eventPublishCnt).isOne
+    }
+
+    @DisplayName("마지막 남은 커플 멤버가 나갈경우 커플을 삭제하고 나간 유저의 상태를 SINGLE로 변경한다.")
+    @Test
+    fun leaveCouple_WithAllMemberLeave() {
+        fun memberLeave(couple: Couple, member: User) {
+            couple.removeMember(member)
+            coupleRepository.save(couple)
+            userRepository.save(member)
+        }
+        // given
+        val (myUser, partnerUser, savedCouple) = makeCouple(userRepository, coupleRepository)
+        memberLeave(savedCouple, partnerUser)
+
+        securityUtilMock.apply {
+            whenever(SecurityUtil.getCurrentUserId()).doReturn(myUser.id)
+        }
+
+        // when
+        coupleService.leaveCouple(savedCouple.id, myUser.id)
+
+        // then - 커플 나가기 이후 상태 변경 확인
+        val inactiveCouple = coupleRepository.findByIdAndNotDeleted(savedCouple.id)
+        val leavedMyUser = userRepository.findByIdAndNotDeleted(myUser.id)
+        assertThat(inactiveCouple).isNull()
+        assertThat(leavedMyUser!!.userStatus).isEqualTo(SINGLE)
+
+        val eventPublishCnt = events.stream(CoupleMemberLeaveEvent::class.java).count()
+        assertThat(eventPublishCnt).isOne
+    }
+}

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
@@ -68,6 +68,12 @@ class CoupleServiceTest @Autowired constructor(
         check(connectionFactory != null)
         connectionFactory.connection.serverCommands().flushAll()
         securityUtilMock = mockStatic(SecurityUtil::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        securityUtilMock.close()  // static mock 초기화
+        reset(redisUtil)  // redisUtil mock 초기화
 
         tagContentMappingRepository.deleteAllInBatch()
         scheduleEventRepository.deleteAllInBatch()
@@ -75,12 +81,6 @@ class CoupleServiceTest @Autowired constructor(
         userRepository.deleteAllInBatch()
         coupleRepository.deleteAllInBatch()
         tagRepository.deleteAllInBatch()
-    }
-
-    @AfterEach
-    fun tearDown() {
-        securityUtilMock.close()  // static mock 초기화
-        reset(redisUtil)  // redisUtil mock 초기화
     }
 
     @DisplayName("사용자 상태가 SINGLE이 아니면 예외가 발생한다.")

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
@@ -1,5 +1,16 @@
 package com.whatever.domain.couple.service
 
+import com.whatever.domain.calendarevent.scheduleevent.model.ScheduleEvent
+import com.whatever.domain.calendarevent.scheduleevent.repository.ScheduleEventRepository
+import com.whatever.domain.content.model.Content
+import com.whatever.domain.content.model.ContentDetail
+import com.whatever.domain.content.model.ContentType.MEMO
+import com.whatever.domain.content.model.ContentType.SCHEDULE
+import com.whatever.domain.content.repository.ContentRepository
+import com.whatever.domain.content.tag.model.Tag
+import com.whatever.domain.content.tag.model.TagContentMapping
+import com.whatever.domain.content.tag.repository.TagContentMappingRepository
+import com.whatever.domain.content.tag.repository.TagRepository
 import com.whatever.domain.couple.controller.dto.request.CreateCoupleRequest
 import com.whatever.domain.couple.controller.dto.request.UpdateCoupleSharedMessageRequest
 import com.whatever.domain.couple.controller.dto.request.UpdateCoupleStartDateRequest
@@ -9,23 +20,27 @@ import com.whatever.domain.couple.exception.CoupleExceptionCode
 import com.whatever.domain.couple.exception.CoupleIllegalArgumentException
 import com.whatever.domain.couple.model.Couple
 import com.whatever.domain.couple.model.CoupleStatus
+import com.whatever.domain.couple.model.CoupleStatus.INACTIVE
 import com.whatever.domain.couple.repository.CoupleRepository
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
 import com.whatever.domain.user.model.UserGender
 import com.whatever.domain.user.model.UserStatus
+import com.whatever.domain.user.model.UserStatus.COUPLED
+import com.whatever.domain.user.model.UserStatus.SINGLE
 import com.whatever.domain.user.repository.UserRepository
 import com.whatever.global.security.util.SecurityUtil
 import com.whatever.util.DateTimeUtil
 import com.whatever.util.RedisUtil
+import com.whatever.util.findByIdAndNotDeleted
 import com.whatever.util.toZonId
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.data.TemporalUnitWithinOffset
+import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.reset
@@ -38,6 +53,9 @@ import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import java.time.temporal.ChronoUnit
+import java.util.*
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -46,6 +64,10 @@ class CoupleServiceTest @Autowired constructor(
     private val coupleService: CoupleService,
     private val userRepository: UserRepository,
     private val coupleRepository: CoupleRepository,
+    private val tagContentMappingRepository: TagContentMappingRepository,
+    private val tagRepository: TagRepository,
+    private val scheduleEventRepository: ScheduleEventRepository,
+    private val contentRepository: ContentRepository,
 ) {
 
     @MockitoSpyBean
@@ -60,7 +82,12 @@ class CoupleServiceTest @Autowired constructor(
         connectionFactory.connection.serverCommands().flushAll()
         securityUtilMock = mockStatic(SecurityUtil::class.java)
 
+        tagContentMappingRepository.deleteAllInBatch()
+        scheduleEventRepository.deleteAllInBatch()
+        contentRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
+        coupleRepository.deleteAllInBatch()
+        tagRepository.deleteAllInBatch()
     }
 
     @AfterEach
@@ -77,7 +104,7 @@ class CoupleServiceTest @Autowired constructor(
             User(
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "test-user-id",
-                userStatus = UserStatus.COUPLED
+                userStatus = COUPLED
             )
         )
         securityUtilMock.apply {
@@ -99,7 +126,7 @@ class CoupleServiceTest @Autowired constructor(
             User(
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "test-user-id",
-                userStatus = UserStatus.SINGLE
+                userStatus = SINGLE
             )
         )
         securityUtilMock.apply {
@@ -127,7 +154,7 @@ class CoupleServiceTest @Autowired constructor(
             User(
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "test-user-id",
-                userStatus = UserStatus.SINGLE
+                userStatus = SINGLE
             )
         )
         securityUtilMock.apply {
@@ -188,7 +215,7 @@ class CoupleServiceTest @Autowired constructor(
                 birthDate = DateTimeUtil.localNow().toLocalDate(),
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "other-user-id",
-                userStatus = UserStatus.COUPLED
+                userStatus = COUPLED
             )
         )
 
@@ -213,7 +240,7 @@ class CoupleServiceTest @Autowired constructor(
                 birthDate = DateTimeUtil.localNow().toLocalDate(),
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "my-user-id",
-                userStatus = UserStatus.SINGLE,
+                userStatus = SINGLE,
                 gender = UserGender.MALE,
             )
         )
@@ -223,7 +250,7 @@ class CoupleServiceTest @Autowired constructor(
                 birthDate = DateTimeUtil.localNow().toLocalDate(),
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "host-user-id",
-                userStatus = UserStatus.SINGLE,
+                userStatus = SINGLE,
                 gender = UserGender.FEMALE,
             )
         )
@@ -254,7 +281,7 @@ class CoupleServiceTest @Autowired constructor(
                 birthDate = DateTimeUtil.localNow().toLocalDate(),
                 platform = LoginPlatform.KAKAO,
                 platformUserId = "host-user-id",
-                userStatus = UserStatus.SINGLE
+                userStatus = SINGLE
             )
         )
         val request = CreateCoupleRequest("test-invitation-code")
@@ -376,6 +403,191 @@ class CoupleServiceTest @Autowired constructor(
         assertThat(result.coupleId).isEqualTo(savedCouple.id)
         assertThat(result.sharedMessage).isNull()
     }
+
+    @DisplayName("커플 멤버 중 한명이 나갈 경우 커플의 상태를 변경하고 나간 유저의 데이터를 soft-delete 한다.")
+    @Test
+    fun leaveCouple() {
+        // given
+        val (myUser, partnerUser, savedCouple) = makeCouple(userRepository, coupleRepository)
+        securityUtilMock.apply {
+            whenever(SecurityUtil.getCurrentUserId()).doReturn(myUser.id)
+        }
+        val tagCount = 20
+        val tags = createTags(tagRepository, tagCount)
+
+        val myDataSize = 20
+        val partnerDataSize = 10
+        val myMemos = createMemos(contentRepository, myUser, myDataSize)
+        val mySchedules = createSchedules(scheduleEventRepository, contentRepository, myUser, myDataSize)
+        val myMappings = createTagContentMappings(tagContentMappingRepository, tags, myMemos)
+
+        val partnerMemos = createMemos(contentRepository, partnerUser, partnerDataSize)
+        val partnerSchedules = createSchedules(scheduleEventRepository, contentRepository, partnerUser, partnerDataSize)
+        val partnerMappings = createTagContentMappings(tagContentMappingRepository, tags, partnerMemos)
+
+        // when
+        coupleService.leaveCouple(savedCouple.id, myUser.id)
+
+        // then - 커플 나가기 이후 상태 변경 확인
+        val inactiveCouple = coupleRepository.findByIdWithMembers(savedCouple.id)
+        require(inactiveCouple != null)
+        assertThat(inactiveCouple.status).isEqualTo(INACTIVE)
+        assertThat(inactiveCouple.members.map { it.id })
+            .doesNotContain(myUser.id)
+            .containsOnly(partnerUser.id)
+
+        val leavedMyUser = userRepository.findByIdAndNotDeleted(myUser.id)
+        val remainingPartnerUser = userRepository.findByIdAndNotDeleted(partnerUser.id)
+        assertThat(leavedMyUser!!.userStatus).isEqualTo(SINGLE)
+        assertThat(remainingPartnerUser!!.userStatus).isEqualTo(COUPLED)
+
+        // then - 커플에서 나간 유저의 데이터 삭제 확인
+        await()
+            .atMost(3, TimeUnit.SECONDS)
+            .pollInterval(300, TimeUnit.MILLISECONDS)
+            .untilAsserted {
+                val remainingContents = contentRepository.findAll().filter { !it.isDeleted && (it.user.id == partnerUser.id) }
+                val remainingMemoContentIds = remainingContents.filter { it.type == MEMO }.map { it.id }
+                val remainingScheduleContentIds = remainingContents.filter { it.type == SCHEDULE }.map { it.id }
+                assertThat(remainingMemoContentIds).containsExactlyInAnyOrderElementsOf(partnerMemos.map { it.id })  //
+                assertThat(remainingScheduleContentIds).containsExactlyInAnyOrderElementsOf(partnerSchedules.map { it.content.id })
+
+                val remainingScheduleIds = scheduleEventRepository.findAll().filter { !it.isDeleted }.map { it.id }
+                assertThat(remainingScheduleIds).containsExactlyInAnyOrderElementsOf(partnerSchedules.map { it.id })
+
+                val remainingMappingIds = tagContentMappingRepository.findAll().filter { !it.isDeleted }.map { it.id }
+                assertThat(remainingMappingIds).containsExactlyInAnyOrderElementsOf(partnerMappings.map { it.id })
+            }
+    }
+
+    @DisplayName("마지막 남은 커플 멤버가 나갈경우 커플과 나간 유저의 데이터를 soft-delete한다.")
+    @Test
+    fun leaveCouple_WithAllMemberLeave() {
+        fun memberLeave(couple: Couple, member: User) {
+            couple.removeMember(member)
+            coupleRepository.save(couple)
+            userRepository.save(member)
+        }
+        // given
+        val (myUser, partnerUser, savedCouple) = makeCouple(userRepository, coupleRepository)
+        memberLeave(savedCouple, partnerUser)
+
+        securityUtilMock.apply {
+            whenever(SecurityUtil.getCurrentUserId()).doReturn(myUser.id)
+        }
+        val tagCount = 20
+        val tags = createTags(tagRepository, tagCount)
+
+        val myDataSize = 20
+        val myMemos = createMemos(contentRepository, myUser, myDataSize)
+        createSchedules(scheduleEventRepository, contentRepository, myUser, myDataSize)
+        createTagContentMappings(tagContentMappingRepository, tags, myMemos)
+
+        // when
+        coupleService.leaveCouple(savedCouple.id, myUser.id)
+
+        // then - 커플 나가기 이후 상태 변경 확인
+        val inactiveCouple = coupleRepository.findByIdAndNotDeleted(savedCouple.id)
+        val leavedMyUser = userRepository.findByIdAndNotDeleted(myUser.id)
+        assertThat(inactiveCouple).isNull()
+        assertThat(leavedMyUser!!.userStatus).isEqualTo(SINGLE)
+
+        // then - 커플에서 나간 유저의 데이터 삭제 확인
+        await()
+            .atMost(3, TimeUnit.SECONDS)
+            .pollInterval(300, TimeUnit.MILLISECONDS)
+            .untilAsserted {
+                val remainingContents = contentRepository.findAll().filter { !it.isDeleted && (it.user.id == myUser.id) }
+                assertThat(remainingContents).isEmpty()
+
+                val remainingScheduleIds = scheduleEventRepository.findAll().filter { !it.isDeleted }
+                assertThat(remainingScheduleIds).isEmpty()
+
+                val remainingMappingIds = tagContentMappingRepository.findAll().filter { !it.isDeleted }
+                assertThat(remainingMappingIds).isEmpty()
+            }
+    }
+
+}
+
+fun createTags(tagRepository: TagRepository, count: Int): List<Tag> {
+    if (count == 0) return emptyList()
+    val tagsToSave = mutableListOf<Tag>()
+    for (i in 1..count) {
+        tagsToSave.add(Tag(label = "Test Tag $i"))
+    }
+    return tagRepository.saveAll(tagsToSave)
+}
+
+fun createMemos(contentRepository: ContentRepository, user: User, count: Int): List<Content> {
+    if (count == 0) return emptyList()
+    val memosToSave = mutableListOf<Content>()
+    for (i in 1..count) {
+        val contentDetail = ContentDetail(title = "Test Memo Title $i", description = "Test Memo Text $i")
+        memosToSave.add(
+            Content(
+                user = user,
+                contentDetail = contentDetail
+            )
+        )
+    }
+    return contentRepository.saveAll(memosToSave)
+}
+
+fun createSchedules(
+    scheduleEventRepository: ScheduleEventRepository,
+    contentRepository: ContentRepository,
+    user: User,
+    count: Int
+): List<ScheduleEvent> {
+    if (count == 0) return emptyList()
+    val contentsToSave = mutableListOf<Content>()
+    val now = DateTimeUtil.localNow()
+    for (i in 1..count) {
+        val contentDetail = ContentDetail(title = "Test Schedule Title $i", description = "Test Schedule Text $i")
+        contentsToSave.add(
+            Content(
+                user = user,
+                contentDetail = contentDetail,
+                type = SCHEDULE
+            )
+        )
+    }
+    val savedContents = contentRepository.saveAll(contentsToSave)
+
+    val schedulesToSave = mutableListOf<ScheduleEvent>()
+    savedContents.forEachIndexed { index, content ->
+        schedulesToSave.add(
+            ScheduleEvent(
+                uid = UUID.randomUUID().toString(),
+                startDateTime = now.plusHours(index.toLong() + 1), // ensure unique times if needed
+                endDateTime = now.plusHours(index.toLong() + 2),
+                startTimeZone = DateTimeUtil.UTC_ZONE_ID,
+                endTimeZone = DateTimeUtil.UTC_ZONE_ID,
+                content = content
+            )
+        )
+    }
+    return scheduleEventRepository.saveAll(schedulesToSave)
+}
+
+fun createTagContentMappings(
+    tagContentMappingRepository: TagContentMappingRepository,
+    tags: List<Tag>,
+    contents: List<Content>
+): List<TagContentMapping> {
+    if (tags.isEmpty() || contents.isEmpty()) return emptyList()
+    val mappingsToSave = mutableListOf<TagContentMapping>()
+    contents.forEach { content ->
+        val mappings = tags.map {
+            TagContentMapping(
+                tag = it,
+                content = content
+            )
+        }
+        mappingsToSave.addAll(mappings)
+    }
+    return tagContentMappingRepository.saveAll(mappingsToSave)
 }
 
 internal fun makeCouple(userRepository: UserRepository, coupleRepository: CoupleRepository): Triple<User, User, Couple> {
@@ -385,7 +597,7 @@ internal fun makeCouple(userRepository: UserRepository, coupleRepository: Couple
             birthDate = DateTimeUtil.localNow().toLocalDate(),
             platform = LoginPlatform.KAKAO,
             platformUserId = "my-user-id",
-            userStatus = UserStatus.SINGLE,
+            userStatus = SINGLE,
             gender = UserGender.MALE,
         )
     )
@@ -395,7 +607,7 @@ internal fun makeCouple(userRepository: UserRepository, coupleRepository: Couple
             birthDate = DateTimeUtil.localNow().toLocalDate(),
             platform = LoginPlatform.KAKAO,
             platformUserId = "partner-user-id",
-            userStatus = UserStatus.SINGLE,
+            userStatus = SINGLE,
             gender = UserGender.FEMALE,
         )
     )

--- a/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/CoupleServiceTest.kt
@@ -408,8 +408,7 @@ internal fun makeCouple(userRepository: UserRepository, coupleRepository: Couple
             sharedMessage = sharedMessage
         )
     )
-    myUser.setCouple(savedCouple)
-    partnerUser.setCouple(savedCouple)
+    savedCouple.addMembers(myUser, partnerUser)
 
     userRepository.save(myUser)
     userRepository.save(partnerUser)

--- a/src/test/kotlin/com/whatever/domain/couple/service/event/CoupleMemberLeaveEventPublishTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/event/CoupleMemberLeaveEventPublishTest.kt
@@ -1,0 +1,103 @@
+package com.whatever.domain.couple.service.event
+
+import com.whatever.config.AsyncConfig
+import com.whatever.domain.calendarevent.scheduleevent.service.event.ScheduleEventCleanupService
+import com.whatever.domain.calendarevent.scheduleevent.service.event.ScheduleEventListener
+import com.whatever.domain.content.service.event.ContentCleanupService
+import com.whatever.domain.content.service.event.ContentEventListener
+import com.whatever.domain.content.tag.service.event.TagContentMappingCleanupService
+import com.whatever.domain.content.tag.service.event.TagContentMappingEventListener
+import com.whatever.domain.couple.service.event.dto.CoupleMemberLeaveEvent
+import org.junit.jupiter.api.DisplayName
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.core.task.SyncTaskExecutor
+import org.springframework.core.task.TaskExecutor
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.transaction.TestTransaction
+import org.springframework.transaction.annotation.Transactional
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Import(SyncAsyncConfig::class)
+class CoupleMemberLeaveEventPublishTest @Autowired constructor(
+    private val applicationEventPublisher: ApplicationEventPublisher
+) : ExcludeAsyncConfigBean(){
+
+    @MockitoBean
+    private lateinit var scheduleEventCleanupService: ScheduleEventCleanupService
+    @MockitoBean
+    private lateinit var contentCleanupService: ContentCleanupService
+    @MockitoBean
+    private lateinit var tagContentMappingCleanupService: TagContentMappingCleanupService
+
+    @DisplayName("CoupleMemberLeaveEvent가 발행되고, commit이 완료되면 각 도메인의 cleanup 서비스가 실행된다.")
+    @Test
+    @Transactional
+    fun publishCoupleMemberLeaveEvent() {
+        // given
+        val coupleId = 0L
+        val userId = 0L
+        val leaveEvent = CoupleMemberLeaveEvent(coupleId, userId)
+
+        // when
+        applicationEventPublisher.publishEvent(leaveEvent)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
+        // then
+        verify(scheduleEventCleanupService, times(1))
+            .cleanupEntity(userId, ScheduleEventListener.ENTITY_NAME)
+        verify(contentCleanupService, times(1))
+            .cleanupEntity(userId, ContentEventListener.ENTITY_NAME)
+        verify(tagContentMappingCleanupService, times(1))
+            .cleanupEntity(userId, TagContentMappingEventListener.ENTITY_NAME)
+    }
+
+    @DisplayName("CoupleMemberLeaveEvent가 발행되고, rollback이 진행된다면 cleanup을 진행하지 않는다.")
+    @Test
+    @Transactional
+    fun publishCoupleMemberLeaveEvent_WithRollback() {
+        // given
+        val coupleId = 0L
+        val userId = 0L
+        val leaveEvent = CoupleMemberLeaveEvent(coupleId, userId)
+
+        // when
+        applicationEventPublisher.publishEvent(leaveEvent)
+        TestTransaction.flagForRollback()
+        TestTransaction.end()
+
+        // then
+        verify(scheduleEventCleanupService, never())
+            .cleanupEntity(userId, ScheduleEventListener.ENTITY_NAME)
+        verify(contentCleanupService, never())
+            .cleanupEntity(userId, ContentEventListener.ENTITY_NAME)
+        verify(tagContentMappingCleanupService, never())
+            .cleanupEntity(userId, TagContentMappingEventListener.ENTITY_NAME)
+    }
+}
+
+@Profile("test")
+@TestConfiguration
+class SyncAsyncConfig {
+    @Bean("taskExecutor")
+    fun syncTaskExecutor(): TaskExecutor {
+        return SyncTaskExecutor()
+    }
+}
+
+abstract class ExcludeAsyncConfigBean {  // AsyncConfig를 비활성화 하기위해 Mocking
+    @MockitoBean
+    private lateinit var asyncConfig: AsyncConfig
+}

--- a/src/test/kotlin/com/whatever/domain/couple/service/event/CoupleMemberLeaveEventPublishTest.kt
+++ b/src/test/kotlin/com/whatever/domain/couple/service/event/CoupleMemberLeaveEventPublishTest.kt
@@ -1,6 +1,8 @@
 package com.whatever.domain.couple.service.event
 
 import com.whatever.config.AsyncConfig
+import com.whatever.domain.balancegame.service.event.UserChoiceOptionCleanupService
+import com.whatever.domain.balancegame.service.event.UserChoiceOptionEventListener
 import com.whatever.domain.calendarevent.scheduleevent.service.event.ScheduleEventCleanupService
 import com.whatever.domain.calendarevent.scheduleevent.service.event.ScheduleEventListener
 import com.whatever.domain.content.service.event.ContentCleanupService
@@ -40,6 +42,8 @@ class CoupleMemberLeaveEventPublishTest @Autowired constructor(
     private lateinit var contentCleanupService: ContentCleanupService
     @MockitoBean
     private lateinit var tagContentMappingCleanupService: TagContentMappingCleanupService
+    @MockitoBean
+    private lateinit var userChoiceOptionCleanupService: UserChoiceOptionCleanupService
 
     @DisplayName("CoupleMemberLeaveEvent가 발행되고, commit이 완료되면 각 도메인의 cleanup 서비스가 실행된다.")
     @Test
@@ -62,6 +66,8 @@ class CoupleMemberLeaveEventPublishTest @Autowired constructor(
             .cleanupEntity(userId, ContentEventListener.ENTITY_NAME)
         verify(tagContentMappingCleanupService, times(1))
             .cleanupEntity(userId, TagContentMappingEventListener.ENTITY_NAME)
+        verify(userChoiceOptionCleanupService, times(1))
+            .cleanupEntity(userId, UserChoiceOptionEventListener.ENTITY_NAME)
     }
 
     @DisplayName("CoupleMemberLeaveEvent가 발행되고, rollback이 진행된다면 cleanup을 진행하지 않는다.")
@@ -85,6 +91,8 @@ class CoupleMemberLeaveEventPublishTest @Autowired constructor(
             .cleanupEntity(userId, ContentEventListener.ENTITY_NAME)
         verify(tagContentMappingCleanupService, never())
             .cleanupEntity(userId, TagContentMappingEventListener.ENTITY_NAME)
+        verify(userChoiceOptionCleanupService, never())
+            .cleanupEntity(userId, UserChoiceOptionEventListener.ENTITY_NAME)
     }
 }
 

--- a/src/test/kotlin/com/whatever/domain/user/model/UserTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/model/UserTest.kt
@@ -1,0 +1,35 @@
+package com.whatever.domain.user.model
+
+import com.whatever.domain.couple.model.Couple
+import com.whatever.domain.user.exception.UserExceptionCode.INVALID_USER_STATUS_FOR_COUPLING
+import com.whatever.domain.user.exception.UserIllegalStateException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class UserTest {
+
+    @DisplayName("SINGLE이 아닌 유저가 커플을 등록할 경우 예외를 반환한다.")
+    @ParameterizedTest
+    @CsvSource("NEW", "COUPLED")
+    fun addMembers_WithIllegalStatusUser(illegalStatus: UserStatus) {
+        // given
+        val couple = Couple()
+        val illegalStatusUser = User(
+            platform = LoginPlatform.KAKAO,
+            platformUserId = "test1",
+            userStatus = illegalStatus,
+        )
+
+        // when
+        val result = assertThrows<UserIllegalStateException> {
+            illegalStatusUser.setCouple(couple)
+        }
+
+        // then
+        assertThat(result.errorCode).isEqualTo(INVALID_USER_STATUS_FOR_COUPLING)
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- close #92 

## 작업한 내용
- 커플 나가기 api 추가

## PR 포인트
- 나가기 이벤트 발행으로 실행되는 cleanup이 실패할 경우, 추가적인 작업을 통해 마저 삭제해야 합니다.(해당 부분 미구현)
- 사용자 데이터를 지우지 않기 때문에, user pk를 사용하여 데이터를 조회하는 경우 새로운 커플 가입 시 이전 정보들이 그대로 나갈 수 있습니다. (잔여 데이터가 완벽히 삭제되지 않을 경우)
- 당장 떠오르는 방법은 다음과 같이 있네요..!
1. 커플이 공유하는 entity는 커플 id를 추가하고, 무조건 coupleId를 통해 조회
2. 데이터 완전 삭제가 보장되는 기간동안 커플을 나간 유저의 새로운 커플 가입 방지