### PR TITLE
[Chore] 태그 조회 api swagger auth 버튼 제거

### DIFF
--- a/src/main/kotlin/com/whatever/domain/content/tag/controller/TagController.kt
+++ b/src/main/kotlin/com/whatever/domain/content/tag/controller/TagController.kt
@@ -3,6 +3,7 @@ package com.whatever.domain.content.tag.controller
 import com.whatever.domain.content.tag.controller.dto.response.TagDetailDto
 import com.whatever.domain.content.tag.controller.dto.response.TagDetailListResponse
 import com.whatever.domain.content.tag.service.TagService
+import com.whatever.global.annotation.DisableSwaggerAuthButton
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
 import io.swagger.v3.oas.annotations.Operation
@@ -21,6 +22,7 @@ class TagController(
     private val tagService: TagService,
 ) {
 
+    @DisableSwaggerAuthButton
     @Operation(
         summary = "태그 조회",
         description = "태그 리스트를 조회합니다.",


### PR DESCRIPTION
## 관련 이슈
- close #127 

## 작업한 내용
- 태그 조회 api swagger auth 버튼 제거
