### PR TITLE
[Refactor] FcmToken 업데이트 dto의 user_id 제거, endpoint 변경

### DIFF
--- a/src/main/kotlin/com/whatever/domain/firebase/controller/FirebaseController.kt
+++ b/src/main/kotlin/com/whatever/domain/firebase/controller/FirebaseController.kt
@@ -4,6 +4,7 @@ import com.whatever.domain.firebase.controller.dto.request.SetFcmTokenRequest
 import com.whatever.domain.firebase.service.FirebaseService
 import com.whatever.global.constants.CaramelHttpHeaders.DEVICE_ID
 import com.whatever.global.exception.dto.CaramelApiResponse
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
@@ -16,7 +17,13 @@ class FirebaseController(
     private val firebaseService: FirebaseService,
 ) {
 
-    @PostMapping
+    @Operation(
+        summary = "fcm token 업데이트",
+        description =
+            "fcm토큰의 수명 관리를 위해 주기적으로 호출해야 하는 api입니다. <br>" +
+            "같은 토큰이더라도 270일동안 해당 api로 호출하지 않았다면 비활성화 됩니다."
+    )
+    @PostMapping("/fcm")
     fun setFcmToken(
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
         @RequestBody request: SetFcmTokenRequest,

--- a/src/main/kotlin/com/whatever/domain/firebase/controller/dto/request/SetFcmTokenRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/firebase/controller/dto/request/SetFcmTokenRequest.kt
@@ -1,6 +1,8 @@
 package com.whatever.domain.firebase.controller.dto.request
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class SetFcmTokenRequest(
-    val userId: Long,
+    @Schema(description = "fcm token")
     val token: String,
 )


### PR DESCRIPTION
## 관련 이슈
- close #152 

## 작업한 내용
- SetFcmTokenRequest의 불필요한 user_id 제거
- fcm 업데이트 api endpont 수정