### PR TITLE
[Hotfix] QA 이슈 해결

### DIFF
--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -86,25 +86,36 @@ class SecurityConfig(
 
         http {
             authorizeHttpRequests {
-                authorize("/v1/auth/sign-out", hasAnyRole(NEW.name, SINGLE.name, COUPLED.name))
+                // 1. Public Access
+                authorize(HttpMethod.POST, "/v1/auth/sign-in", permitAll)
+                authorize(HttpMethod.POST, "/v1/auth/refresh", permitAll)
+                 authorize("/sample/**", permitAll)
 
+                // 2. Role: NEW
                 authorize(HttpMethod.POST, "/v1/user/profile", hasAnyRole(NEW.name))
-                authorize("/v1/user/me", hasAnyRole(NEW.name, SINGLE.name, COUPLED.name))
-                authorize("/v1/user/**", hasAnyRole(SINGLE.name, COUPLED.name))
 
-                authorize("/v1/content/**", hasAnyRole(COUPLED.name))
-
+                // 3. Role: SINGLE
                 authorize("/v1/couples/invitation-code", hasAnyRole(SINGLE.name))
                 authorize("/v1/couples/connect", hasAnyRole(SINGLE.name))
-                authorize("/v1/couples/**", hasAnyRole(COUPLED.name))
 
-                authorize("/v1/calendar/holidays", hasAnyRole(COUPLED.name))
-                authorize("/v1/calendar/schedules/**", hasAnyRole(COUPLED.name))
+                // 4. Role: COUPLED
                 authorize("/v1/calendar/**", hasAnyRole(COUPLED.name))
-
+                authorize("/v1/content/**", hasAnyRole(COUPLED.name))
+                authorize("/v1/couples/{couple-id}/**", hasAnyRole(COUPLED.name))
+                authorize("/v1/couples/me", hasAnyRole(COUPLED.name))
                 authorize("/v1/balance-game/**", hasAnyRole(COUPLED.name))
+                authorize(HttpMethod.GET, "/v1/tags", hasAnyRole(COUPLED.name))
 
-                authorize(anyRequest, permitAll)  // TODO(준용) API에 따른 Role 추가 필요, 현재 임시로 모두 허용
+                // 5. Authenticated Users
+                authorize("/v1/auth/sign-out", authenticated)
+                authorize(HttpMethod.DELETE, "/v1/auth/account", authenticated)
+                authorize("/v1/user/me", authenticated) // 모든 인증된 사용자는 자신의 정보를 볼 수 있음
+
+                // 6. Service Members
+                authorize("/v1/user/**", hasAnyRole(SINGLE.name, COUPLED.name))
+
+                // 7. Default Rule
+                authorize(anyRequest, authenticated)
             }
         }
 

--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -56,7 +56,7 @@ class SecurityConfig(
     @Value("\${swagger.password}")
     lateinit var swaggerPassword: String
 
-    @Profile("production", "dev")
+    @Profile("dev")
     @Bean
     @Order(1)
     fun swaggerFilterChain(http: HttpSecurity): SecurityFilterChain {

--- a/src/main/kotlin/com/whatever/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SwaggerConfig.kt
@@ -1,6 +1,7 @@
 package com.whatever.config
 
 import com.whatever.global.annotation.DisableSwaggerAuthButton
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.models.Components
@@ -13,6 +14,7 @@ import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.web.method.HandlerMethod
 
 @OpenAPIDefinition(
@@ -23,6 +25,7 @@ import org.springframework.web.method.HandlerMethod
     )
 )
 @Configuration
+@Profile("!production")
 class SwaggerConfig {
 
     @Value("\${swagger.local-server-url}")

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
@@ -7,6 +7,7 @@ import com.whatever.domain.content.model.ContentDetail.Companion.MAX_TITLE_LENGT
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.CodePointLength
 import java.time.LocalDateTime
 
 @Schema(description = "일정 생성 요청 모델")
@@ -16,11 +17,11 @@ data class CreateScheduleRequest(
 //    val contentId: Long,
 
     @Schema(description = "콘텐츠 제목. title, description 둘 중 하나는 필수입니다.", example = "맛집 리스트", nullable = true)
-    @field:Size(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
+    @field:CodePointLength(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
     val title: String? = null,
 
     @Schema(description = "콘텐츠 설명. title, description 둘 중 하나는 필수입니다.", example = "어제 함께 갔던 맛집들", nullable = true)
-    @field:Size(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
+    @field:CodePointLength(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
     val description: String? = null,
 
     @Schema(description = "완료 여부")

--- a/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
@@ -1,7 +1,11 @@
 package com.whatever.domain.calendarevent.scheduleevent.controller.dto
 
+import com.whatever.domain.content.model.ContentDetail.Companion.MAX_DESCRIPTION_LENGTH
+import com.whatever.domain.content.model.ContentDetail.Companion.MAX_TITLE_LENGTH
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.CodePointLength
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -12,11 +16,11 @@ data class UpdateScheduleRequest(
     val selectedDate: LocalDate,
 
     @Schema(description = "콘텐츠 제목. title, description 둘 중 하나는 필수입니다.", example = "맛집 리스트", nullable = true)
-    @field:NotBlank(message = "제목은 공백일 수 없습니다.")
+    @field:CodePointLength(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
     val title: String? = null,
 
-    @field:NotBlank(message = "본문은 공백일 수 없습니다.")
     @Schema(description = "콘텐츠 설명. title, description 둘 중 하나는 필수입니다.", example = "어제 함께 갔던 맛집들", nullable = true)
+    @field:CodePointLength(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
     val description: String? = null,
 
     @Schema(description = "완료 여부")

--- a/src/main/kotlin/com/whatever/domain/content/controller/ContentController.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/ContentController.kt
@@ -78,7 +78,7 @@ class ContentController(
     @PutMapping("/memo/{memo-id}")
     fun updateContent(
         @PathVariable("memo-id") contentId: Long,
-        @RequestBody request: UpdateContentRequest,
+        @Valid @RequestBody request: UpdateContentRequest,
     ): CaramelApiResponse<ContentSummaryResponse> {
         return contentService.updateContent(contentId, request).succeed()
     }

--- a/src/main/kotlin/com/whatever/domain/content/controller/dto/request/CreateContentRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/dto/request/CreateContentRequest.kt
@@ -5,17 +5,18 @@ import com.whatever.domain.content.model.ContentDetail.Companion.MAX_TITLE_LENGT
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED
 import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.CodePointLength
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Schema(description = "콘텐츠 생성 요청 모델")
 data class CreateContentRequest(
     @Schema(description = "콘텐츠 제목. title, description 둘 중 하나는 필수입니다.", example = "맛집 리스트")
-    @field:Size(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
+    @field:CodePointLength(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
     val title: String? = null,
 
     @Schema(description = "콘텐츠 설명. title, description 둘 중 하나는 필수입니다.", example = "어제 함께 갔던 맛집들")
-    @field:Size(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
+    @field:CodePointLength(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
     val description: String? = null,
 
     @Schema(

--- a/src/main/kotlin/com/whatever/domain/content/controller/dto/request/UpdateContentRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/content/controller/dto/request/UpdateContentRequest.kt
@@ -1,14 +1,19 @@
 package com.whatever.domain.content.controller.dto.request
 
+import com.whatever.domain.content.model.ContentDetail.Companion.MAX_DESCRIPTION_LENGTH
+import com.whatever.domain.content.model.ContentDetail.Companion.MAX_TITLE_LENGTH
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED
+import org.hibernate.validator.constraints.CodePointLength
 
 @Schema(description = "콘텐츠 수정 요청 모델")
 data class UpdateContentRequest(
     @Schema(description = "콘텐츠 제목", example = "맛집 리스트")
+    @field:CodePointLength(max = MAX_TITLE_LENGTH, message = "제목은 최대 ${MAX_TITLE_LENGTH}자까지 가능합니다.")
     val title: String?,
 
     @Schema(description = "콘텐츠 설명", example = "어제 함께 갔던 맛집들")
+    @field:CodePointLength(max = MAX_DESCRIPTION_LENGTH, message = "설명은 최대 ${MAX_DESCRIPTION_LENGTH}자까지 가능합니다.")
     val description: String?,
 
     @Schema(description = "완료 여부", requiredMode = NOT_REQUIRED)

--- a/src/main/kotlin/com/whatever/domain/content/service/MemoCreator.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/MemoCreator.kt
@@ -27,12 +27,8 @@ class MemoCreator(
         isCompleted: Boolean,
         tagIds: Set<Long>,
     ): Content {
-        val replacedTitle = when {
-            title.isNullOrBlank() && !description.isNullOrBlank() -> description.take(MAX_TITLE_LENGTH)
-            else -> title!!
-        }
         val contentDetail = ContentDetail(
-            title = replacedTitle,
+            title = title,
             description = description,
             isCompleted = isCompleted
         )

--- a/src/main/kotlin/com/whatever/domain/content/service/ScheduleCreator.kt
+++ b/src/main/kotlin/com/whatever/domain/content/service/ScheduleCreator.kt
@@ -35,12 +35,8 @@ class ScheduleCreator(
         tagIds: Set<Long>,
         dateTimeInfo: DateTimeInfoDto,
     ): ScheduleEvent {
-        val replacedTitle = when {
-            title.isNullOrBlank() && !description.isNullOrBlank() -> description.take(MAX_TITLE_LENGTH)
-            else -> title!!
-        }
         val contentDetail = ContentDetail(
-            title = replacedTitle,
+            title = title,
             description = description,
             isCompleted = isCompleted
         )

--- a/src/main/kotlin/com/whatever/domain/couple/controller/dto/request/UpdateCoupleRequest.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/controller/dto/request/UpdateCoupleRequest.kt
@@ -4,6 +4,7 @@ import com.whatever.domain.couple.model.Couple.Companion.MAX_SHARED_MESSAGE_LENG
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED
 import jakarta.validation.constraints.Size
+import org.hibernate.validator.constraints.CodePointLength
 import java.time.LocalDate
 
 @Schema(description = "커플 시작일 수정 요청 모델")
@@ -17,6 +18,6 @@ data class UpdateCoupleSharedMessageRequest(
         description = "공유 메시지. Allow Null, Not Blank",
         requiredMode = REQUIRED
     )
-    @field:Size(max = MAX_SHARED_MESSAGE_LENGTH, message = "Maximum description length is ${MAX_SHARED_MESSAGE_LENGTH}")
+    @field:CodePointLength(max = MAX_SHARED_MESSAGE_LENGTH, message = "Maximum description length is ${MAX_SHARED_MESSAGE_LENGTH}")
     val sharedMessage: String?,
 )

--- a/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
+++ b/src/main/kotlin/com/whatever/domain/couple/model/Couple.kt
@@ -34,7 +34,7 @@ class Couple(
     var startDate: LocalDate? = null,
 
     @Column(length = MAX_SHARED_MESSAGE_LENGTH_WITH_BUFFER)
-    @field:CodePointLength(max = MAX_SHARED_MESSAGE_LENGTH)
+    @field:CodePointLength(max = MAX_SHARED_MESSAGE_LENGTH, message = "Maximum description length is ${MAX_SHARED_MESSAGE_LENGTH}")
     var sharedMessage: String? = null,
 
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/com/whatever/domain/sample/controller/SampleController.kt
+++ b/src/main/kotlin/com/whatever/domain/sample/controller/SampleController.kt
@@ -22,6 +22,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
@@ -32,6 +33,7 @@ import java.time.LocalDate
     description = "간단한 예제를 담은 샘플 API 입니다."
 )
 @RestController
+@RequestMapping("/sample")
 class SampleController(
     private val sampleService: SampleService,
 ) {

--- a/src/main/kotlin/com/whatever/global/security/filter/RequestResponseLoggingFilter.kt
+++ b/src/main/kotlin/com/whatever/global/security/filter/RequestResponseLoggingFilter.kt
@@ -19,6 +19,10 @@ private val requestFilterLogger = KotlinLogging.logger { }
 class RequestResponseLoggingFilter(
     private val objectMapper: ObjectMapper,
 ) : OncePerRequestFilter() {
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return !LOGGING_PATTERN.containsMatchIn(request.requestURI)
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -117,7 +121,7 @@ class RequestResponseLoggingFilter(
         private const val MAX_BODY_LENGTH = 500
         private val CARAMEL_HEADER_NAMES = CaramelHttpHeaders.ALL_HEADERS.map { it.lowercase() }.toSet()
         private val SENSITIVE_HEADER_PATTERN = Regex("(?i)authorization|device-id")
-//        private val SHOULD_NOT_LOGGING_PATTERN = Regex("(?i)")
+        private val LOGGING_PATTERN = Regex("(?i)/v1/")
     }
 }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -159,6 +159,9 @@ otel:
       resource:
         providers: ${OTEL_DISABLED_PROVIDERS}
 
+springdoc:
+  api-docs:
+    enabled: false
 ---
 # ┌───────────────────────────── Dev 프로파일 ─────────────────────────────
 spring:

--- a/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/ScheduleControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/calendarevent/scheduleevent/controller/ScheduleControllerTest.kt
@@ -39,14 +39,40 @@ class ScheduleControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("스케줄을 업데이트 시 제목은 공백을 제외한 문자여야 한다.")
+    @DisplayName("스케줄을 업데이트 시 제목은 최대 30글자여야 한다.")
     @Test
-    fun updateSchedule_WithBlankTitle() {
+    fun updateSchedule_WithTitleLength30() {
         // given
+        val titleLength30 = "\uD83D\uDC4D".repeat(30)  // 👍
         val request = UpdateScheduleRequest(
             selectedDate = DateTimeUtil.localNow().toLocalDate(),
-            title = "     ",  // Blank Title
-            description = "new description",
+            title = titleLength30,
+            description = "test-desc",
+            isCompleted = false,
+            startDateTime = DateTimeUtil.localNow(),
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
+        )
+
+        // when, then
+        mockMvc.put("/v1/calendar/schedules/${SCHEDULE_ID}") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @DisplayName("스케줄을 업데이트 시 제목이 30글자 초과라면 예외가 발생한다.")
+    @Test
+    fun updateSchedule_WithTitleLength31() {
+        // given
+        val titleLength31 = "\uD83D\uDC4D".repeat(31)  // 👍
+        val request = UpdateScheduleRequest(
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = titleLength31,
+            description = "test-desc",
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
@@ -64,14 +90,40 @@ class ScheduleControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("스케줄을 업데이트 시 본문은 공백을 제외한 문자여야 한다.")
+    @DisplayName("스케줄을 업데이트 시 본문은 최대 5000글자여야 한다.")
     @Test
-    fun updateSchedule_WithBlankDescription() {
+    fun updateSchedule_WithDescriptionLength5000() {
         // given
+        val descriptionLength5000 = "\uD83D\uDC4D".repeat(5000)
         val request = UpdateScheduleRequest(
             selectedDate = DateTimeUtil.localNow().toLocalDate(),
-            title = "new title",
-            description = "     ",  // Blank Title
+            title = "test-title",
+            description = descriptionLength5000,
+            isCompleted = false,
+            startDateTime = DateTimeUtil.localNow(),
+            startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
+        )
+
+        // when, then
+        mockMvc.put("/v1/calendar/schedules/${SCHEDULE_ID}") {
+            content = objectMapper.writeValueAsString(request)
+            contentType = MediaType.APPLICATION_JSON
+        }
+            .andDo { print() }
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @DisplayName("스케줄을 업데이트 시 제목이 30글자 초과라면 예외가 발생한다.")
+    @Test
+    fun updateSchedule_WithDescriptionLength5001() {
+        // given
+        val descriptionLength5001 = "\uD83D\uDC4D".repeat(5001)
+        val request = UpdateScheduleRequest(
+            selectedDate = DateTimeUtil.localNow().toLocalDate(),
+            title = "test-title",
+            description = descriptionLength5001,
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,


### PR DESCRIPTION
## 관련 이슈
- close #176 

## 작업한 내용
- 운영 환경 swaager 비활성화되도록 SwaggerConfig에 Profile추가, application.yaml에서 api-doc 비활성화
- security 엔드포인트 인가 정보 최신화
- 유효한 endpoint에만 request logging이 진행되도록 shouldNotFilter() 추가
- @Size를 통해 입력 길이를 검증하던 요소를 @CodePointLength로 변경
- content의 title이 null로 넘어오는 경우 DB에 그대로 저장