### PR TITLE
[Fix] metric 수집 api permit all

### DIFF
--- a/src/main/kotlin/com/whatever/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/whatever/config/SecurityConfig.kt
@@ -55,8 +55,10 @@ class SecurityConfig(
     lateinit var swaggerUser: String
     @Value("\${swagger.password}")
     lateinit var swaggerPassword: String
+    @Value("\${management.endpoints.web.base-path}")
+    lateinit var actuatorPath: String
 
-    @Profile("dev")
+    @Profile("production", "dev")
     @Bean
     @Order(1)
     fun swaggerFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -89,7 +91,8 @@ class SecurityConfig(
                 // 1. Public Access
                 authorize(HttpMethod.POST, "/v1/auth/sign-in", permitAll)
                 authorize(HttpMethod.POST, "/v1/auth/refresh", permitAll)
-                 authorize("/sample/**", permitAll)
+                authorize("/sample/**", permitAll)
+                authorize("${actuatorPath}/**", permitAll)
 
                 // 2. Role: NEW
                 authorize(HttpMethod.POST, "/v1/user/profile", hasAnyRole(NEW.name))


### PR DESCRIPTION
## 관련 이슈
- close #179 

## 작업한 내용
- metric 수집용 api의 접근 권한을 모두 허용 (reverse proxy에서 차단)
