### PR TITLE
[Fix] 최초 가입 시 소셜 닉네임 길이가 invalid하다면 null 처리

### DIFF
--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/AppleUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/AppleUserProvider.kt
@@ -7,6 +7,8 @@ import com.whatever.domain.auth.dto.AppleUserName
 import com.whatever.domain.auth.service.OIDCHelper
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.User.Companion.MAX_NICKNAME_LENGTH
+import com.whatever.domain.user.model.User.Companion.MIN_NICKNAME_LENGTH
 import com.whatever.domain.user.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
@@ -74,5 +76,5 @@ private fun AppleIdTokenPayload.toUser(userName: AppleUserName? = null) = User(
     platform = LoginPlatform.APPLE,
     platformUserId = sub,
     email = email,
-    nickname = userName?.toString()
+    nickname = userName?.toString()?.takeIf { it.length in MIN_NICKNAME_LENGTH..MAX_NICKNAME_LENGTH }
 )

--- a/src/main/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProvider.kt
+++ b/src/main/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProvider.kt
@@ -6,13 +6,13 @@ import com.whatever.domain.auth.client.KakaoOIDCClient
 import com.whatever.domain.auth.client.dto.KakaoIdTokenPayload
 import com.whatever.domain.auth.client.dto.KakaoUnlinkUserRequest
 import com.whatever.domain.auth.service.OIDCHelper
-import com.whatever.domain.user.exception.UserExceptionCode
 import com.whatever.domain.user.exception.UserExceptionCode.NOT_FOUND
 import com.whatever.domain.user.exception.UserNotFoundException
 import com.whatever.domain.user.model.LoginPlatform
 import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.User.Companion.MAX_NICKNAME_LENGTH
+import com.whatever.domain.user.model.User.Companion.MIN_NICKNAME_LENGTH
 import com.whatever.domain.user.repository.UserRepository
-import com.whatever.global.security.util.SecurityUtil
 import com.whatever.util.findByIdAndNotDeleted
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
@@ -70,6 +70,6 @@ class KakaoUserProvider(
 private fun KakaoIdTokenPayload.toUser() = User(
     platform = LoginPlatform.KAKAO,
     platformUserId = platformUserId,
-    nickname = nickname,
+    nickname = nickname?.takeIf { it.length in MIN_NICKNAME_LENGTH..MAX_NICKNAME_LENGTH },
     email = email,
 )

--- a/src/main/kotlin/com/whatever/domain/user/model/User.kt
+++ b/src/main/kotlin/com/whatever/domain/user/model/User.kt
@@ -10,7 +10,6 @@ import com.whatever.global.exception.ErrorUi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.persistence.*
 import org.hibernate.validator.constraints.CodePointLength
-import org.springframework.context.annotation.DependsOn
 import org.springframework.security.crypto.encrypt.TextEncryptor
 import org.springframework.stereotype.Component
 import java.time.LocalDate
@@ -44,7 +43,7 @@ class User(
     val platformUserId: String,
 
     @Column(length = 8)
-    @field:CodePointLength(min = 2, max = 8)
+    @field:CodePointLength(min = MIN_NICKNAME_LENGTH, max = MAX_NICKNAME_LENGTH)
     var nickname: String? = null,
 
     @Enumerated(EnumType.STRING)
@@ -98,6 +97,8 @@ class User(
     companion object {
         const val MAX_GENDER_LENGTH = 50
         const val MAX_STATUS_LENGTH = 50
+        const val MIN_NICKNAME_LENGTH = 2
+        const val MAX_NICKNAME_LENGTH = 8
     }
 }
 

--- a/src/test/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProviderTest.kt
+++ b/src/test/kotlin/com/whatever/domain/auth/service/provider/KakaoUserProviderTest.kt
@@ -7,7 +7,10 @@ import com.whatever.domain.auth.service.OIDCHelper
 import com.whatever.domain.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -86,5 +89,65 @@ class KakaoUserProviderTest @Autowired constructor(
 
         assertThat(successCnt.toInt()).isEqualTo(threadCount)
         assertThat(failCnt.toInt()).isEqualTo(0)
+    }
+
+    @DisplayName("카카오로 가입 시, 카카오 닉네임이 2~8자를 벗어나면, null로 취급한다.")
+    @ParameterizedTest
+    @CsvSource("1", "123456789")
+    fun findOrCreateUser_WithInvalidLengthKakaoNickname(invalidLengthNickname: String) {
+        // given
+        Mockito.`when`(kakaoOIDCClient.getOIDCPublicKey())
+            .thenReturn(OIDCPublicKeysResponse())
+
+        Mockito.`when`(oidcHelper.parseKakaoIdToken(Mockito.anyString(), Mockito.anyList()))
+            .thenReturn(KakaoIdTokenPayload(
+                iss = "",
+                aud = "",
+                sub = "social-user-id",
+                iat = 1L,
+                exp = 1L,
+                authTime = 1L,
+                nickname = invalidLengthNickname,
+            ))
+
+        // when
+        val result = kakaoUserProvider.findOrCreateUser("any-id-token")
+
+        // then
+        assertThat(result.nickname).isNull()
+
+        val savedUsers = userRepository.findAll()
+        assertThat(savedUsers).hasSize(1)
+        assertThat(savedUsers.first().nickname).isNull()
+    }
+
+    @DisplayName("카카오로 가입 시, 카카오 닉네임이 2~8자 이내라면 DB에 저장한다.")
+    @ParameterizedTest
+    @CsvSource("12", "12345678")
+    fun findOrCreateUser_WithValidLengthKakaoNickname(validLengthNickname: String) {
+        // given
+        Mockito.`when`(kakaoOIDCClient.getOIDCPublicKey())
+            .thenReturn(OIDCPublicKeysResponse())
+
+        Mockito.`when`(oidcHelper.parseKakaoIdToken(Mockito.anyString(), Mockito.anyList()))
+            .thenReturn(KakaoIdTokenPayload(
+                iss = "",
+                aud = "",
+                sub = "social-user-id",
+                iat = 1L,
+                exp = 1L,
+                authTime = 1L,
+                nickname = validLengthNickname,
+            ))
+
+        // when
+        val result = kakaoUserProvider.findOrCreateUser("any-id-token")
+
+        // then
+        assertThat(result.nickname).isEqualTo(validLengthNickname)
+
+        val savedUsers = userRepository.findAll()
+        assertThat(savedUsers).hasSize(1)
+        assertThat(savedUsers.first().nickname).isEqualTo(validLengthNickname)
     }
 }


### PR DESCRIPTION
## 관련 이슈
- close #189 

## 작업한 내용
- idToken에 있는 user 닉네임의 길이가 invalid할 경우, null로 취급하도록 확장함수 수정
- 해당 케이스의 테스트 코드 추가