### PR TITLE
[Refactor] /user birthdate validation

### DIFF
--- a/src/main/kotlin/com/whatever/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/whatever/domain/user/controller/UserController.kt
@@ -8,8 +8,10 @@ import com.whatever.domain.user.dto.PostUserProfileResponse
 import com.whatever.domain.user.dto.PutUserProfileRequest
 import com.whatever.domain.user.dto.PutUserProfileResponse
 import com.whatever.domain.user.service.UserService
+import com.whatever.global.constants.CaramelHttpHeaders.TIME_ZONE
 import com.whatever.global.exception.dto.CaramelApiResponse
 import com.whatever.global.exception.dto.succeed
+import com.whatever.util.toZonId
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -40,8 +42,9 @@ class UserController(
     @PutMapping("/profile")
     fun updateProfile(
         @Valid @RequestBody putUserProfileRequest: PutUserProfileRequest,
+        @RequestHeader(TIME_ZONE) timeZone: String,
     ): CaramelApiResponse<PutUserProfileResponse> {
-        val userProfileResponse = userService.updateProfile(putUserProfileRequest)
+        val userProfileResponse = userService.updateProfile(putUserProfileRequest, timeZone.toZonId())
         return userProfileResponse.succeed()
     }
 
@@ -60,9 +63,10 @@ class UserController(
     )
     @PostMapping("/profile")
     fun createProfile(
-        @Valid @RequestBody postUserProfileRequest: PostUserProfileRequest
+        @Valid @RequestBody postUserProfileRequest: PostUserProfileRequest,
+        @RequestHeader(TIME_ZONE) timeZone: String,
     ): CaramelApiResponse<PostUserProfileResponse> {
-        val userProfileResponse = userService.createProfile(postUserProfileRequest)
+        val userProfileResponse = userService.createProfile(postUserProfileRequest, timeZone.toZonId())
         return userProfileResponse.succeed()
     }
 

--- a/src/main/kotlin/com/whatever/domain/user/exception/UserException.kt
+++ b/src/main/kotlin/com/whatever/domain/user/exception/UserException.kt
@@ -17,3 +17,8 @@ class UserIllegalStateException(
     errorCode: UserExceptionCode,
     errorUi: ErrorUi,
 ) : UserException(errorCode, errorUi)
+
+class UserIllegalArgumentException(
+    errorCode: UserExceptionCode,
+    errorUi: ErrorUi,
+) : UserException(errorCode, errorUi)

--- a/src/main/kotlin/com/whatever/domain/user/exception/UserExceptionCode.kt
+++ b/src/main/kotlin/com/whatever/domain/user/exception/UserExceptionCode.kt
@@ -31,6 +31,10 @@ enum class UserExceptionCode(
         message = "설정 정보가 존재하지 않습니다.",
         status = HttpStatus.CONFLICT
     ),
+    INVALID_BIRTH_DATE(
+        sequence = "010",
+        message = "생일은 미래 날짜로 설정할 수 없습니다."
+    ),
     ;
 
     override val code = "USER$sequence"

--- a/src/main/kotlin/com/whatever/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/whatever/domain/user/service/UserService.kt
@@ -19,6 +19,7 @@ import com.whatever.global.security.util.SecurityUtil.getCurrentUserId
 import com.whatever.util.findByIdAndNotDeleted
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.ZoneId
 
 
 @Service
@@ -27,13 +28,13 @@ class UserService(
     private val userSettingRepository: UserSettingRepository,
 ) {
     @Transactional
-    fun createProfile(postUserProfileRequest: PostUserProfileRequest): PostUserProfileResponse {
+    fun createProfile(postUserProfileRequest: PostUserProfileRequest, userTimeZone: ZoneId): PostUserProfileResponse {
         val userId = getCurrentUserId()
         val user = userRepository.findByIdAndNotDeleted(userId)
             ?: throw UserNotFoundException(NOT_FOUND)
 
         with(postUserProfileRequest) {
-            user.register(nickname, birthday, gender)
+            user.register(nickname, birthday, gender, userTimeZone)
         }
 
         if (!userSettingRepository.existsByUserAndIsDeleted(user)) {
@@ -48,7 +49,7 @@ class UserService(
     }
 
     @Transactional
-    fun updateProfile(putUserProfileRequest: PutUserProfileRequest): PutUserProfileResponse {
+    fun updateProfile(putUserProfileRequest: PutUserProfileRequest, userTimeZone: ZoneId): PutUserProfileResponse {
         val userId = getCurrentUserId()
         val user = userRepository.findByIdAndNotDeleted(userId)?.apply {
             if (putUserProfileRequest.nickname.isNullOrBlank().not()) {
@@ -56,7 +57,7 @@ class UserService(
             }
 
             if (putUserProfileRequest.birthday != null) {
-                birthDate = putUserProfileRequest.birthday
+                updateBirthDate(putUserProfileRequest.birthday, userTimeZone)
             }
         }
 

--- a/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/controller/UserControllerTest.kt
@@ -5,6 +5,7 @@ import com.whatever.domain.user.dto.PostUserProfileRequest
 import com.whatever.domain.user.dto.PutUserProfileRequest
 import com.whatever.domain.user.dto.PutUserProfileResponse
 import com.whatever.domain.user.model.UserGender
+import com.whatever.global.constants.CaramelHttpHeaders
 import com.whatever.global.exception.GlobalExceptionCode
 import com.whatever.util.DateTimeUtil
 import org.junit.jupiter.api.DisplayName
@@ -34,6 +35,7 @@ class UserControllerTest : ControllerTestSupport() {
         mockMvc.post("/v1/user/profile") {
             content = objectMapper.writeValueAsString(request)
             contentType = MediaType.APPLICATION_JSON
+            header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
         }
             .andDo { print() }
             .andExpect {
@@ -57,6 +59,7 @@ class UserControllerTest : ControllerTestSupport() {
         mockMvc.post("/v1/user/profile") {
             content = objectMapper.writeValueAsString(request)
             contentType = MediaType.APPLICATION_JSON
+            header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
         }
             .andDo { print() }
             .andExpect {
@@ -65,12 +68,12 @@ class UserControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("프로필을 등록할 때 닉네임은 1자 초과여야 한다.")
+    @DisplayName("프로필을 등록할 때 닉네임은 0자 초과여야 한다.")
     @Test
     fun createProfile_WithBelowMinLengthNickname() {
         // given
         val request = PostUserProfileRequest(
-            nickname = "1",
+            nickname = "",
             birthday = DateTimeUtil.localNow().toLocalDate(),
             agreementServiceTerms = true,
             agreementPrivatePolicy = true,
@@ -126,6 +129,7 @@ class UserControllerTest : ControllerTestSupport() {
         mockMvc.put("/v1/user/profile") {
             content = objectMapper.writeValueAsString(request)
             contentType = MediaType.APPLICATION_JSON
+            header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
         }
             .andDo { print() }
             .andExpect {
@@ -154,12 +158,12 @@ class UserControllerTest : ControllerTestSupport() {
             }
     }
 
-    @DisplayName("프로필을 수정할 때 닉네임은 2~8자여야 한다. (최소 길이 미만)")
+    @DisplayName("프로필을 수정할 때 닉네임은 1~8자여야 한다. (최소 길이 미만)")
     @Test
     fun updateProfile_WithBelowMinLengthNickname() {
         // given
         val request = PutUserProfileRequest(
-            nickname = "a",  // 1자
+            nickname = "",  // 0자
             birthday = DateTimeUtil.localNow().toLocalDate(),
         )
 
@@ -188,6 +192,7 @@ class UserControllerTest : ControllerTestSupport() {
         mockMvc.put("/v1/user/profile") {
             content = objectMapper.writeValueAsString(request)
             contentType = MediaType.APPLICATION_JSON
+            header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
         }
             .andDo { print() }
             .andExpect {
@@ -209,6 +214,7 @@ class UserControllerTest : ControllerTestSupport() {
         mockMvc.put("/v1/user/profile") {
             content = objectMapper.writeValueAsString(request)
             contentType = MediaType.APPLICATION_JSON
+            header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
         }
             .andDo { print() }
             .andExpect {
@@ -228,6 +234,7 @@ class UserControllerTest : ControllerTestSupport() {
         mockMvc.put("/v1/user/profile") {
             content = objectMapper.writeValueAsString(request)
             contentType = MediaType.APPLICATION_JSON
+            header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
         }
             .andDo { print() }
             .andExpect {
@@ -243,7 +250,7 @@ class UserControllerTest : ControllerTestSupport() {
         fun updateProfile_WithBlankNickname_NoChange() {
             val originalNickname = "변경전닉네임"
             val originalBirthday = LocalDate.of(2025, 4, 20)
-            given(userService.updateProfile(any()))
+            given(userService.updateProfile(any(), any()))
                 .willReturn(
                     PutUserProfileResponse(
                         id = 1,
@@ -261,6 +268,7 @@ class UserControllerTest : ControllerTestSupport() {
             mockMvc.put("/v1/user/profile") {
                 content = objectMapper.writeValueAsString(updateRequest)
                 contentType = MediaType.APPLICATION_JSON
+                header(CaramelHttpHeaders.TIME_ZONE, DateTimeUtil.KST_ZONE_ID.toString())
             }
                 .andDo { print() }
                 .andExpect {

--- a/src/test/kotlin/com/whatever/domain/user/model/UserTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/model/UserTest.kt
@@ -1,13 +1,17 @@
 package com.whatever.domain.user.model
 
 import com.whatever.domain.couple.model.Couple
+import com.whatever.domain.user.exception.UserExceptionCode.INVALID_BIRTH_DATE
 import com.whatever.domain.user.exception.UserExceptionCode.INVALID_USER_STATUS_FOR_COUPLING
+import com.whatever.domain.user.exception.UserIllegalArgumentException
 import com.whatever.domain.user.exception.UserIllegalStateException
+import com.whatever.util.DateTimeUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.Test
 
 class UserTest {
 
@@ -30,6 +34,39 @@ class UserTest {
 
         // then
         assertThat(result.errorCode).isEqualTo(INVALID_USER_STATUS_FOR_COUPLING)
+    }
+
+    @DisplayName("생일 Date는 반드시 과거여야 한다.")
+    @Test
+    fun updateBirthDate() {
+        // given
+        val user = User(platform = LoginPlatform.TEST, platformUserId = "test-p-id")
+        val requestTimeZone = DateTimeUtil.KST_ZONE_ID
+        val pastDate = DateTimeUtil.zonedNow(requestTimeZone).minusDays(1).toLocalDate()  // valid
+
+        // when
+        user.updateBirthDate(pastDate, requestTimeZone)
+
+
+        // then
+        assertThat(user.birthDate).isEqualTo(pastDate)
+    }
+
+    @DisplayName("미래 시간으로 생일을 설정할 경우 예외를 반환한다.")
+    @Test
+    fun updateBirthDate_withFutureDate() {
+        // given
+        val user = User(platform = LoginPlatform.TEST, platformUserId = "test-p-id")
+        val requestTimeZone = DateTimeUtil.KST_ZONE_ID
+        val futureDate = DateTimeUtil.zonedNow(requestTimeZone).plusDays(1).toLocalDate()  // invalid
+
+        // when
+        val exception = assertThrows<UserIllegalArgumentException> {
+            user.updateBirthDate(futureDate, requestTimeZone)
+        }
+
+        // then
+        assertThat(exception.errorCode).isEqualTo(INVALID_BIRTH_DATE)
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
- close #192 

## 작업한 내용
- User entity에 updateBIrthDate() 메서드를 추가하고, validation을 진행했습니다.

## PR 포인트
- 클라이언트에서 모든 요청에 사용자 TimeZone을 헤더로 전송하고 있습니다. 해당 정보를 받아서 validation을 진행했습니다.