### PR TITLE
[Feat] update user setting 유닛 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,11 +151,3 @@ tasks.jacocoTestReport {
 
     classDirectories.setFrom(filteredClasses)
 }
-
-tasks.test {
-    configure {
-        exclude(
-            // 논의후 추가
-        )
-    }
-}

--- a/src/main/kotlin/com/whatever/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/whatever/domain/user/service/UserService.kt
@@ -85,7 +85,7 @@ class UserService(
             )
 
         with(request) {
-            request.notificationEnabled?.let { userSetting.notificationEnabled = it }
+            notificationEnabled?.let { userSetting.notificationEnabled = it }
         }
 
         return UserSettingResponse.from(userSetting)

--- a/src/test/kotlin/com/whatever/domain/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/service/UserServiceTest.kt
@@ -79,7 +79,7 @@ class UserServiceTest {
     }
 }
 
-fun createNewUser(
+internal fun createNewUser(
     userRepository: UserRepository,
 ): User {
     return createUser(
@@ -88,7 +88,7 @@ fun createNewUser(
     )
 }
 
-fun createSingleUser(
+internal fun createSingleUser(
     userRepository: UserRepository,
     birthDate: LocalDate,
     nickname: String,
@@ -103,7 +103,7 @@ fun createSingleUser(
     )
 }
 
-fun createUser(
+internal fun createUser(
     userRepository: UserRepository,
     email: String? = null,
     birthDate: LocalDate? = null,

--- a/src/test/kotlin/com/whatever/domain/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/service/UserServiceTest.kt
@@ -8,15 +8,9 @@ import com.whatever.domain.user.model.User
 import com.whatever.domain.user.model.UserGender
 import com.whatever.domain.user.model.UserStatus
 import com.whatever.domain.user.repository.UserRepository
-import com.whatever.global.security.util.SecurityUtil
 import com.whatever.util.DateTimeUtil
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
-import org.mockito.Mockito.mockStatic
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.mock
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles

--- a/src/test/kotlin/com/whatever/domain/user/service/UserServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/service/UserServiceUnitTest.kt
@@ -13,28 +13,30 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.InjectMocks
+import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.mockStatic
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.UUID
 import kotlin.test.Test
 
 @ActiveProfiles("test")
-@SpringBootTest
+@ExtendWith(MockitoExtension::class)
 class UserServiceUnitTest {
 
-    @MockitoBean
+    @Mock
     private lateinit var mockUserRepository: UserRepository
 
-    @MockitoBean
+    @Mock
     private lateinit var mockUserSettingRepository: UserSettingRepository
 
-    @Autowired
+    @InjectMocks
     private lateinit var userService: UserService
 
     private lateinit var mockSecurityUtil: AutoCloseable
@@ -46,7 +48,7 @@ class UserServiceUnitTest {
 
     @AfterEach
     fun tearDown() {
-        mockSecurityUtil.close()  // static mock 초기화
+        mockSecurityUtil.close()
     }
 
     @ParameterizedTest
@@ -60,18 +62,15 @@ class UserServiceUnitTest {
             platform = LoginPlatform.TEST,
             platformUserId = UUID.randomUUID().toString()
         )
-        Mockito.`when`(mockUserRepository.save(Mockito.any(User::class.java)))
-            .thenReturn(user)
-
         val userSetting = UserSetting(user = user, notificationEnabled = setting)
-        Mockito.`when`(
+        whenever(
             mockUserSettingRepository.findByUserAndIsDeleted(
                 user = user,
                 isDeleted = false,
             )
         ).thenReturn(userSetting)
 
-        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+        whenever(mockUserRepository.getReferenceById(Mockito.anyLong()))
             .thenReturn(user)
 
         /**
@@ -96,18 +95,16 @@ class UserServiceUnitTest {
             platform = LoginPlatform.TEST,
             platformUserId = UUID.randomUUID().toString()
         )
-        Mockito.`when`(mockUserRepository.save(Mockito.any(User::class.java)))
-            .thenReturn(user)
 
         val userSetting = UserSetting(user = user, notificationEnabled = setting)
-        Mockito.`when`(
+        whenever(
             mockUserSettingRepository.findByUserAndIsDeleted(
                 user = user,
                 isDeleted = false,
             )
         ).thenReturn(userSetting)
 
-        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+        whenever(mockUserRepository.getReferenceById(Mockito.anyLong()))
             .thenReturn(user)
 
         // when
@@ -126,10 +123,8 @@ class UserServiceUnitTest {
             platform = LoginPlatform.TEST,
             platformUserId = UUID.randomUUID().toString()
         )
-        Mockito.`when`(mockUserRepository.save(Mockito.any(User::class.java)))
-            .thenReturn(user)
 
-        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+        whenever(mockUserRepository.getReferenceById(Mockito.anyLong()))
             .thenReturn(user)
 
         // when
@@ -150,10 +145,10 @@ class UserServiceUnitTest {
             platformUserId = UUID.randomUUID().toString()
         )
         mockSecurityUtil.apply {
-            Mockito.`when`(SecurityUtil.getCurrentUserId()).thenReturn(user.id)
+            whenever(SecurityUtil.getCurrentUserId()).thenReturn(user.id)
         }
 
-        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+        whenever(mockUserRepository.getReferenceById(Mockito.anyLong()))
             .thenReturn(user)
 
         // when

--- a/src/test/kotlin/com/whatever/domain/user/service/UserServiceUnitTest.kt
+++ b/src/test/kotlin/com/whatever/domain/user/service/UserServiceUnitTest.kt
@@ -1,0 +1,168 @@
+package com.whatever.domain.user.service
+
+import com.whatever.domain.user.dto.PatchUserSettingRequest
+import com.whatever.domain.user.exception.UserExceptionCode
+import com.whatever.domain.user.exception.UserIllegalStateException
+import com.whatever.domain.user.model.LoginPlatform
+import com.whatever.domain.user.model.User
+import com.whatever.domain.user.model.UserSetting
+import com.whatever.domain.user.repository.UserRepository
+import com.whatever.domain.user.repository.UserSettingRepository
+import com.whatever.global.security.util.SecurityUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.Mockito
+import org.mockito.Mockito.mockStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.UUID
+import kotlin.test.Test
+
+@ActiveProfiles("test")
+@SpringBootTest
+class UserServiceUnitTest {
+
+    @MockitoBean
+    private lateinit var mockUserRepository: UserRepository
+
+    @MockitoBean
+    private lateinit var mockUserSettingRepository: UserSettingRepository
+
+    @Autowired
+    private lateinit var userService: UserService
+
+    private lateinit var mockSecurityUtil: AutoCloseable
+
+    @BeforeEach
+    fun setUp() {
+        mockSecurityUtil = mockStatic(SecurityUtil::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockSecurityUtil.close()  // static mock 초기화
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "true", "false"
+    )
+    fun `유저의 세팅을 업데이트 합니다`(setting: Boolean) {
+        // given
+        val user = User(
+            id = 1L,
+            platform = LoginPlatform.TEST,
+            platformUserId = UUID.randomUUID().toString()
+        )
+        Mockito.`when`(mockUserRepository.save(Mockito.any(User::class.java)))
+            .thenReturn(user)
+
+        val userSetting = UserSetting(user = user, notificationEnabled = setting)
+        Mockito.`when`(
+            mockUserSettingRepository.findByUserAndIsDeleted(
+                user = user,
+                isDeleted = false,
+            )
+        ).thenReturn(userSetting)
+
+        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+            .thenReturn(user)
+
+        /**
+         * 요청에서 setting을 반대로 주면?
+         */
+        // when
+        val request = PatchUserSettingRequest(notificationEnabled = setting.not())
+        val result = userService.updateUserSetting(request = request, userId = user.id)
+
+        // then
+        assertThat(result.notificationEnabled).isEqualTo(setting.not())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "true", "false"
+    )
+    fun `유저의 세팅을 업데이트 - Request null 이면 기존 그대로 응답`(setting: Boolean) {
+        // given
+        val user = User(
+            id = 1L,
+            platform = LoginPlatform.TEST,
+            platformUserId = UUID.randomUUID().toString()
+        )
+        Mockito.`when`(mockUserRepository.save(Mockito.any(User::class.java)))
+            .thenReturn(user)
+
+        val userSetting = UserSetting(user = user, notificationEnabled = setting)
+        Mockito.`when`(
+            mockUserSettingRepository.findByUserAndIsDeleted(
+                user = user,
+                isDeleted = false,
+            )
+        ).thenReturn(userSetting)
+
+        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+            .thenReturn(user)
+
+        // when
+        val request = PatchUserSettingRequest(notificationEnabled = null)
+        val result = userService.updateUserSetting(request = request, userId = user.id)
+
+        // then
+        assertThat(result.notificationEnabled).isEqualTo(setting)
+    }
+
+    @Test
+    fun `유저의 세팅을 업데이트 하려하지만, 유저 설정 정보를 찾을 수 없음`() {
+        // given
+        val user = User(
+            id = 1L,
+            platform = LoginPlatform.TEST,
+            platformUserId = UUID.randomUUID().toString()
+        )
+        Mockito.`when`(mockUserRepository.save(Mockito.any(User::class.java)))
+            .thenReturn(user)
+
+        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+            .thenReturn(user)
+
+        // when
+        val request = PatchUserSettingRequest(notificationEnabled = true)
+        val result = assertThrows<UserIllegalStateException> {
+            userService.updateUserSetting(request = request, userId = user.id)
+        }
+        // then
+        assertThat(result.errorCode).isEqualTo(UserExceptionCode.SETTING_DATA_NOT_FOUND)
+    }
+
+    @Test
+    fun `유저의 세팅을 업데이트 - getCurrentUserId() 에 문제 없음`() {
+        // given
+        val user = User(
+            id = 1L,
+            platform = LoginPlatform.TEST,
+            platformUserId = UUID.randomUUID().toString()
+        )
+        mockSecurityUtil.apply {
+            Mockito.`when`(SecurityUtil.getCurrentUserId()).thenReturn(user.id)
+        }
+
+        Mockito.`when`(mockUserRepository.getReferenceById(Mockito.anyLong()))
+            .thenReturn(user)
+
+        // when
+        val request = PatchUserSettingRequest(notificationEnabled = true)
+        val result = assertThrows<UserIllegalStateException> {
+            userService.updateUserSetting(request = request)
+        }
+
+        // then
+        assertThat(result.errorCode).isEqualTo(UserExceptionCode.SETTING_DATA_NOT_FOUND)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업한 내용
- updateUserSetting 테스트 코드 추가
- jacoco 추가한 김에 updateUserSetting 쪽 테스트 코드를 추가해봤습니다
- 이전 테스트랑 겹치지 않게 파일 분리했습니다
- 테스트용 함수 internal로 변경해서 외부에서 못쓰게 바꿨습니당
- 준용님 pr 머지 되어야지 UserControllerTest 성공합니다

## PR 포인트
- getCurrentUserId() 쪽을 잘 몰라서 따라했습니다ㅠ 
- 테스트코드 수정 할 부분 or 추가할 테스트가 있으면 알려주세요 !
- mockito는 처음써봐서 ㅠ 틀린게 있으면 알려주세요
- 이 테스트 에서는 getCurrentUserId() 를 넣어주고 말고의 여부만 테스트 했습니다
 ( 그 이상의 에러 테스트는 여기 테스트 코드의 책임이 아닌 것 가타서요 ,,!!)

before
![image](https://github.com/user-attachments/assets/91529acc-a07e-478a-9b63-5ce9f305bade)

after
![스크린샷 2025-07-09 오전 3 11 10](https://github.com/user-attachments/assets/591654f2-94f1-4061-a310-a0bfc6dc7518)
