### PR TITLE
[Test] balance game 테스트 코드 추가

### DIFF
--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
@@ -111,8 +111,8 @@ class BalanceGameService(
         coupleId: Long,
         gameId: Long,
     ): List<UserChoiceOptionVo> {
-        val memberIds = coupleRepository.findByIdWithMembers(coupleId)?.members?.map { it.id }
-            ?: return emptyList()
+        val couple = coupleRepository.findByIdWithMembers(coupleId) ?: return emptyList()
+        val memberIds = couple.members.map { it.id }
         val memberChoices = userChoiceOptionRepository.findAllWithOptionByBalanceGameIdAndUsers(
             gameId = gameId,
             userIds = memberIds,

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
@@ -95,7 +95,7 @@ class BalanceGameService(
         gameId: Long,
     ): List<UserChoiceOptionVo> {
         val couple = coupleRepository.findByIdWithMembers(coupleId) ?: return emptyList()
-        val memberIds = couple.members.map { it.id }
+        val memberIds = couple.members.map { it.id }.ifEmpty { return emptyList() }
         val memberChoices = userChoiceOptionRepository.findAllWithOptionByBalanceGameIdAndUsers(
             gameId = gameId,
             userIds = memberIds,

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
@@ -83,23 +83,6 @@ class BalanceGameService(
         )
     }
 
-    /**
-     * VO로 이전
-     * 병합 후 삭제
-     */
-//    private fun getSortedActiveBalanceGameOptions(
-//        options: List<BalanceGameOption>,
-//    ): List<BalanceGameOption> {
-//        val sortedOptions = options.filter { !it.isDeleted }.sortedBy { it.id }
-//        if (sortedOptions.size < 2) {
-//            throw BalanceGameIllegalStateException(
-//                errorCode = GAME_OPTION_NOT_ENOUGH,
-//                errorUi = ErrorUi.Toast("밸런스 게임의 선택지가 모두 등록되지 않았어요.")
-//            )
-//        }
-//        return sortedOptions
-//    }
-
     private fun getBalanceGame(
         date: LocalDate = DateTimeUtil.localNow(TARGET_ZONE_ID).toLocalDate(),
     ): BalanceGame {

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -186,31 +186,6 @@ class BalanceGameServiceTest @Autowired constructor(
         }
     }
 
-    @DisplayName("밸런스 게임을 조회 시 커플멤버가 비어있는 경우(emptySet) emptyList 를 반환한다.")
-    @Test
-    fun getTodayBalanceGameInfo_() {
-        // given
-        val couple = mock<Couple>()
-        val now = LocalDateTime.of(2025, 5, 5, 9, 0)
-        mockStatic(DateTimeUtil::class.java).use {
-            whenever(DateTimeUtil.localNow(any())).thenReturn(now)
-            val expectedGame = makeBalanceGame(1, now.toLocalDate()).first()
-
-            val coupleRepository = mock<CoupleRepository>()
-            mock<CoupleRepository> {
-                on { findByIdWithMembers(anyLong()) } doReturn couple
-            }
-            val balanceGameService =
-                BalanceGameService(balanceGameRepository, userChoiceOptionRepository, coupleRepository, userRepository)
-
-            // when
-            val result = balanceGameService.getCoupleMemberChoices(couple.id, expectedGame.first.id)
-
-            // then
-            assertThat(result.size).isEqualTo(0)
-        }
-    }
-
     @DisplayName("커플의 밸런스 게임 선택 조회시, Couple Id로 조회했는데 없는 경우 emptyList 를 반환한다")
     @Test
     fun getCoupleMemberChoices_WhenFindByIdWithMembersReturnsNull() {

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -31,7 +31,9 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.contracts.contract
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 @CaramelDomainSpringBootTest
 class BalanceGameServiceTest @Autowired constructor(
@@ -270,9 +272,9 @@ class BalanceGameServiceTest @Autowired constructor(
             )
 
             // then
-            assertThat(result.myChoice).isNotNull
-            assertThat(result.myChoice!!.balanceGameId).isEqualTo(gameId)
-            assertThat(result.myChoice!!.balanceGameOptionId).isEqualTo(selectedOptionId)
+            val myChoice = assertNotNull(result.myChoice)
+            assertThat(myChoice.balanceGameId).isEqualTo(gameId)
+            assertThat(myChoice.balanceGameOptionId).isEqualTo(selectedOptionId)
             assertThat(result.partnerChoice).isNull()
         }
     }
@@ -307,9 +309,9 @@ class BalanceGameServiceTest @Autowired constructor(
             )
 
             // then
-            assertThat(result.myChoice).isNotNull
-            assertThat(result.myChoice!!.balanceGameId).isEqualTo(myChoiceOption.balanceGame.id)
-            assertThat(result.myChoice!!.balanceGameOptionId).isEqualTo(myChoiceOption.balanceGameOption.id)
+            val myChoice = assertNotNull(result.myChoice)
+            assertThat(myChoice.balanceGameId).isEqualTo(myChoiceOption.balanceGame.id)
+            assertThat(myChoice.balanceGameOptionId).isEqualTo(myChoiceOption.balanceGameOption.id)
             assertThat(result.partnerChoice).isNull()
         }
     }

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -194,10 +194,30 @@ class BalanceGameServiceTest @Autowired constructor(
         val now = LocalDateTime.of(2025, 5, 5, 9, 0)
         val expectedGame = makeBalanceGame(1, now.toLocalDate()).first()
         val coupleRepository = mock<CoupleRepository>()
-        mock<CoupleRepository> {
-            on { findByIdWithMembers(anyLong()) } doReturn null
-        }
-        whenever(coupleRepository.findByIdWithMembers(anyLong())).doReturn(null)
+        whenever(coupleRepository.findByIdWithMembers(anyLong())).thenReturn(null)
+
+        val balanceGameService =
+            BalanceGameService(balanceGameRepository, userChoiceOptionRepository, coupleRepository, userRepository)
+
+        // when
+        val userChoices = balanceGameService.getCoupleMemberChoices(couple.id, expectedGame.first.id)
+
+        // then
+        assertThat(userChoices.size).isEqualTo(0)
+    }
+
+    @DisplayName("커플의 밸런스 게임 선택 조회시, Couple 안의 MemberId 가 빈 경우 emptyList 를 반환한다")
+    @Test
+    fun getCoupleMemberChoices_WhenMembersIsEmpty() {
+        // given
+        val (user1, user2, couple) = setUpCouple()
+        val now = LocalDateTime.of(2025, 5, 5, 9, 0)
+        val expectedGame = makeBalanceGame(1, now.toLocalDate()).first()
+        val coupleRepository = mock<CoupleRepository>()
+        whenever(coupleRepository.findByIdWithMembers(anyLong())).thenReturn(couple.apply {
+            removeMember(user1)
+            removeMember(user2)
+        })
         val balanceGameService =
             BalanceGameService(balanceGameRepository, userChoiceOptionRepository, coupleRepository, userRepository)
 

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -203,7 +203,7 @@ class BalanceGameServiceTest @Autowired constructor(
         val userChoices = balanceGameService.getCoupleMemberChoices(couple.id, expectedGame.first.id)
 
         // then
-        assertThat(userChoices.size).isEqualTo(0)
+        assertThat(userChoices).isEmpty()
     }
 
     @DisplayName("커플의 밸런스 게임 선택 조회시, Couple 안의 MemberId 가 빈 경우 emptyList 를 반환한다")
@@ -225,7 +225,7 @@ class BalanceGameServiceTest @Autowired constructor(
         val userChoices = balanceGameService.getCoupleMemberChoices(couple.id, expectedGame.first.id)
 
         // then
-        assertThat(userChoices.size).isEqualTo(0)
+        assertThat(userChoices).isEmpty()
     }
 
     @DisplayName("밸런스 게임을 조회 시 선택지가 두개 미만일 경우 예외가 발생한다.")

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -200,9 +200,9 @@ class BalanceGameServiceTest @Autowired constructor(
             )
 
             // then
-            require(result.myChoice != null)
-            assertThat(result.myChoice.balanceGameId).isEqualTo(gameId)
-            assertThat(result.myChoice.balanceGameOptionId).isEqualTo(selectedOptionId)
+            assertThat(result.myChoice).isNotNull
+            assertThat(result.myChoice!!.balanceGameId).isEqualTo(gameId)
+            assertThat(result.myChoice!!.balanceGameOptionId).isEqualTo(selectedOptionId)
             assertThat(result.partnerChoice).isNull()
         }
     }
@@ -237,9 +237,9 @@ class BalanceGameServiceTest @Autowired constructor(
             )
 
             // then
-            require(result.myChoice != null)
-            assertThat(result.myChoice.balanceGameId).isEqualTo(myChoiceOption.balanceGame.id)
-            assertThat(result.myChoice.balanceGameOptionId).isEqualTo(myChoiceOption.balanceGameOption.id)
+            assertThat(result.myChoice).isNotNull
+            assertThat(result.myChoice!!.balanceGameId).isEqualTo(myChoiceOption.balanceGame.id)
+            assertThat(result.myChoice!!.balanceGameOptionId).isEqualTo(myChoiceOption.balanceGameOption.id)
             assertThat(result.partnerChoice).isNull()
         }
     }
@@ -275,14 +275,14 @@ class BalanceGameServiceTest @Autowired constructor(
             )
 
             // then
-            require(result.myChoice != null)
-            assertThat(result.myChoice.balanceGameId).isEqualTo(gameId)
-            assertThat(result.myChoice.balanceGameOptionId).isEqualTo(selectedOptionId)
+            assertThat(result.myChoice).isNotNull
+            assertThat(result.myChoice!!.balanceGameId).isEqualTo(gameId)
+            assertThat(result.myChoice!!.balanceGameOptionId).isEqualTo(selectedOptionId)
 
-            require(result.partnerChoice != null)
+            assertThat(result.partnerChoice).isNotNull
             with(partnerChoiceOption) {
-                assertThat(result.partnerChoice.balanceGameId).isEqualTo(balanceGame.id)
-                assertThat(result.partnerChoice.balanceGameOptionId).isEqualTo(balanceGameOption.id)
+                assertThat(result.partnerChoice!!.balanceGameId).isEqualTo(balanceGame.id)
+                assertThat(result.partnerChoice!!.balanceGameOptionId).isEqualTo(balanceGameOption.id)
             }
         }
     }


### PR DESCRIPTION
## 관련 이슈
- close #223

## 작업한 내용
- balance game test code 추가 했어요 ! 
- 주석 따라서 필요 없다해서 지운 함수가 있어요 !
- 오타 수정했슴다
 
<img width="976" height="138" alt="image" src="https://github.com/user-attachments/assets/bda8937e-319e-4b69-8e6a-ad83a8792035" />


## PR 포인트
Couple 내부에 member는 non-null type의 set으로 되어있는데요,
```
protected val mutableMembers: MutableSet<com.whatever.caramel.domain.user.model.User> = mutableSetOf()
val members: Set<com.whatever.caramel.domain.user.model.User> get() = mutableMembers.toSet()
```

getCoupleMemberChoices 에서 아래와 같이 non-nullable 한 members를 findByIdWithMembers 때문에 같이 nullable하게 쓰고 있더라구요
```
...
val couple = coupleRepository.findByIdWithMembers(coupleId)?.members?.map { it.id } ?: return emptyList()
...
```
그래서 아래와 같이 2부분으로 나누어서 더 명확하게 사용했어요
```
val couple = coupleRepository.findByIdWithMembers(coupleId) ?: return emptyList()
val memberIds = couple.members.map { it.id }.ifEmpty { return emptyList() }
```
커버리지 측정하다보니 이게 맞는 것 같아서요 ...

한줄요약 :  non-null type 인데 non-null 하게 쓰고 있지 않은 것 같아서 수정했다
