### PR TITLE
[Bug] ContentInfoResponse 에서 tagList 응답 잘못 내려가는 것 수정

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/response/ContentInfoResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/response/ContentInfoResponse.kt
@@ -18,7 +18,7 @@ data class ContentResponse(
     @Schema(description = "완료 여부")
     val isCompleted: Boolean,
     @Schema(description = "연관 태그 Id 리스트")
-    val tagList: List<Long>,
+    val tagList: List<TagDto>,
     @Schema(description = "생성일")
     val createdAt: LocalDate,
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
@@ -27,7 +27,7 @@ data class ContentResponse(
     companion object {
         fun from(
             content: Content,
-            tagList: List<Long>,
+            tagList: List<TagDto>,
         ) = ContentResponse(
             id = content.id,
             title = content.contentDetail.title ?: "",
@@ -44,7 +44,7 @@ data class ContentResponse(
                 title = contentResponseVo.title,
                 description = contentResponseVo.description,
                 isCompleted = contentResponseVo.isCompleted,
-                tagList = contentResponseVo.tagList.map { it.id },
+                tagList = contentResponseVo.tagList.map { TagDto.from(it) },
                 createdAt = contentResponseVo.createdAt,
                 contentAsignee = contentResponseVo.contentAsignee
             )


### PR DESCRIPTION
## 관련 이슈
- close  #231
- https://whatever-xhr4427.slack.com/archives/C082BGJP546/p1753466387466629 

## 작업한 내용
- TagTto 같아서 수정했습니당

## PR 포인트
- 맞나요~?