### PR TITLE
[Fix] /v1/calendar/schedules 에서 응답 모듈화 전으로 롤백

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/ScheduleController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/ScheduleController.kt
@@ -1,6 +1,8 @@
 package com.whatever.caramel.api.calendarevent.scheduleevent.controller
 
 import com.whatever.caramel.api.calendarevent.controller.dto.request.GetCalendarQueryParameter
+import com.whatever.caramel.api.calendarevent.controller.dto.response.CalendarDetailResponse
+import com.whatever.caramel.api.calendarevent.controller.dto.response.CalendarEventsDto
 import com.whatever.caramel.api.calendarevent.controller.dto.response.ScheduleDetailDto
 import com.whatever.caramel.api.calendarevent.scheduleevent.controller.dto.CreateScheduleRequest
 import com.whatever.caramel.api.calendarevent.scheduleevent.controller.dto.GetScheduleResponse
@@ -45,7 +47,7 @@ class ScheduleController(
     @GetMapping
     fun getSchedules(
         @ParameterObject queryParameter: GetCalendarQueryParameter,
-    ): CaramelApiResponse<List<ScheduleDetailDto>> {
+    ): CaramelApiResponse<CalendarDetailResponse> {
         val scheduleDetailsVo = scheduleEventService.getSchedules(
             startDate = queryParameter.startDate,
             endDate = queryParameter.endDate,
@@ -53,9 +55,13 @@ class ScheduleController(
             currentUserCoupleId = getCurrentUserCoupleId(),
         )
 
-        return scheduleDetailsVo.scheduleDetailVoList
+        val scheduleList = scheduleDetailsVo.scheduleDetailVoList
             .map { ScheduleDetailDto.from(it) }
-            .succeed()
+        
+        val calendarResult = CalendarEventsDto(scheduleList = scheduleList)
+        val response = CalendarDetailResponse(calendarResult = calendarResult)
+        
+        return response.succeed()
     }
 
     @Operation(


### PR DESCRIPTION
## 관련 이슈
- close #233 
- https://whatever-xhr4427.slack.com/archives/C082BGJP546/p1753468042528169

## 작업한 내용
- 이전 응답 형식으로 롤백하였습니다.
- 바뀐 형식으로 배포하게 되면 프로덕션 앱이랑 싱크가 안맞습니다.