### PR TITLE
[Refactor] content assinee 철자 오류 수정, 구버전 클라이언트와 api 호환성을 위한 cotnentAssinee default 값 추가

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/controller/dto/response/CalendarEventInfoResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/controller/dto/response/CalendarEventInfoResponse.kt
@@ -43,7 +43,7 @@ data class ScheduleDetailDto(
     val description: String?,
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(scheduleDetailVo: ScheduleDetailVo): ScheduleDetailDto {
@@ -57,7 +57,7 @@ data class ScheduleDetailDto(
                 parentScheduleId = scheduleDetailVo.parentScheduleId,
                 title = scheduleDetailVo.title,
                 description = scheduleDetailVo.description,
-                contentAsignee = scheduleDetailVo.contentAsignee,
+                contentAssignee = scheduleDetailVo.contentAssignee,
             )
         }
     }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
@@ -39,7 +39,7 @@ data class CreateScheduleRequest(
     val tagIds: Set<TagIdDto> = emptySet(),
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     fun toVo(): CreateScheduleVo {
         return CreateScheduleVo(
@@ -51,7 +51,7 @@ data class CreateScheduleRequest(
             endDateTime = this.endDateTime,
             endTimeZone = this.endTimeZone,
             tagIds = this.tagIds.map { it.tagId }.toSet(),
-            contentAsignee = this.contentAsignee,
+            contentAssignee = this.contentAssignee,
         )
     }
 }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/CreateScheduleRequest.kt
@@ -39,7 +39,7 @@ data class CreateScheduleRequest(
     val tagIds: Set<TagIdDto> = emptySet(),
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAssignee: ContentAssignee,
+    val contentAssignee: ContentAssignee = ContentAssignee.ME,
 ) {
     fun toVo(): CreateScheduleVo {
         return CreateScheduleVo(

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
@@ -43,7 +43,7 @@ data class UpdateScheduleRequest(
     val tagIds: Set<TagIdDto> = emptySet(),
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAssignee: ContentAssignee,
+    val contentAssignee: ContentAssignee = ContentAssignee.ME,
 ) {
     fun toVo(): UpdateScheduleVo {
         return UpdateScheduleVo(

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/dto/UpdateScheduleRequest.kt
@@ -43,7 +43,7 @@ data class UpdateScheduleRequest(
     val tagIds: Set<TagIdDto> = emptySet(),
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     fun toVo(): UpdateScheduleVo {
         return UpdateScheduleVo(
@@ -56,7 +56,7 @@ data class UpdateScheduleRequest(
             endDateTime = this.endDateTime,
             endTimeZone = this.endTimeZone,
             tagIds = this.tagIds.map { it.tagId }.toSet(),
-            contentAsignee = this.contentAsignee,
+            contentAssignee = this.contentAssignee,
         )
     }
 }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/CreateContentRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/CreateContentRequest.kt
@@ -34,7 +34,7 @@ data class CreateContentRequest(
     val tags: List<TagIdDto> = emptyList(),
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     fun toVo(): CreateContentRequestVo {
         return CreateContentRequestVo(
@@ -42,7 +42,7 @@ data class CreateContentRequest(
             description = this.description,
             isCompleted = this.isCompleted,
             tags = this.tags.map { it.tagId },
-            contentAsignee = this.contentAsignee
+            contentAssignee = this.contentAssignee
         )
     }
 }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/CreateContentRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/CreateContentRequest.kt
@@ -34,7 +34,7 @@ data class CreateContentRequest(
     val tags: List<TagIdDto> = emptyList(),
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAssignee: ContentAssignee,
+    val contentAssignee: ContentAssignee = ContentAssignee.ME,
 ) {
     fun toVo(): CreateContentRequestVo {
         return CreateContentRequestVo(

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/UpdateContentRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/UpdateContentRequest.kt
@@ -29,7 +29,7 @@ data class UpdateContentRequest(
     val dateTimeInfo: DateTimeInfoDto? = null,
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAssignee: ContentAssignee,
+    val contentAssignee: ContentAssignee = ContentAssignee.ME,
 ) {
 
     fun toVo(): UpdateContentRequestVo {

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/UpdateContentRequest.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/request/UpdateContentRequest.kt
@@ -29,7 +29,7 @@ data class UpdateContentRequest(
     val dateTimeInfo: DateTimeInfoDto? = null,
 
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
 
     fun toVo(): UpdateContentRequestVo {
@@ -39,7 +39,7 @@ data class UpdateContentRequest(
             isCompleted = this.isCompleted,
             tagList = this.tagList.map { it.tagId },
             dateTimeInfo = this.dateTimeInfo?.toVo(),
-            contentAsignee = this.contentAsignee
+            contentAssignee = this.contentAssignee
         )
     }
 }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/response/ContentInfoResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/content/controller/dto/response/ContentInfoResponse.kt
@@ -22,7 +22,7 @@ data class ContentResponse(
     @Schema(description = "생성일")
     val createdAt: LocalDate,
     @Schema(description = "컨텐츠 담당자 (ME: 나, PARTNER: 상대방, US: 우리)")
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(
@@ -35,7 +35,7 @@ data class ContentResponse(
             isCompleted = content.contentDetail.isCompleted,
             tagList = tagList,
             createdAt = content.getCreatedAtInZone(KST_ZONE_ID).toLocalDate(),
-            contentAsignee = content.contentAsignee
+            contentAssignee = content.contentAssignee
         )
 
         fun from(contentResponseVo: ContentResponseVo): ContentResponse {
@@ -46,7 +46,7 @@ data class ContentResponse(
                 isCompleted = contentResponseVo.isCompleted,
                 tagList = contentResponseVo.tagList.map { TagDto.from(it) },
                 createdAt = contentResponseVo.createdAt,
-                contentAsignee = contentResponseVo.contentAsignee
+                contentAssignee = contentResponseVo.contentAssignee
             )
         }
     }

--- a/caramel-api/src/test/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/ScheduleControllerTest.kt
+++ b/caramel-api/src/test/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/ScheduleControllerTest.kt
@@ -43,7 +43,7 @@ class ScheduleControllerTest : ControllerTestSupport() {
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
         every { SecurityUtil.getCurrentUserCoupleId() } returns 0L
         every { SecurityUtil.getCurrentUserId() } returns 0L
@@ -71,7 +71,7 @@ class ScheduleControllerTest : ControllerTestSupport() {
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         every { SecurityUtil.getCurrentUserCoupleId() } returns 0L
         every { SecurityUtil.getCurrentUserId() } returns 0L
@@ -99,7 +99,7 @@ class ScheduleControllerTest : ControllerTestSupport() {
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when, then
@@ -126,7 +126,7 @@ class ScheduleControllerTest : ControllerTestSupport() {
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         every { SecurityUtil.getCurrentUserCoupleId() } returns 0L
         every { SecurityUtil.getCurrentUserId() } returns 0L
@@ -154,7 +154,7 @@ class ScheduleControllerTest : ControllerTestSupport() {
             isCompleted = false,
             startDateTime = DateTimeUtil.localNow(),
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when, then

--- a/caramel-api/src/test/kotlin/com/whatever/caramel/api/content/controller/ContentControllerTest.kt
+++ b/caramel-api/src/test/kotlin/com/whatever/caramel/api/content/controller/ContentControllerTest.kt
@@ -43,7 +43,7 @@ class ContentControllerTest : ControllerTestSupport() {
             title = "메모 제목",
             description = "메모 설명",
             tags = listOf(TagIdDto(1L)),
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
         whenever(contentService.createContent(any(), any(), any()))
             .thenReturn(ContentSummaryVo(0L, ContentType.MEMO))
@@ -100,7 +100,7 @@ class ContentControllerTest : ControllerTestSupport() {
             description = "",
             isCompleted = false,
             tags = emptyList(),
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when // then
@@ -124,7 +124,7 @@ class ContentControllerTest : ControllerTestSupport() {
             description = "수정된 설명",
             isCompleted = true,
             tagList = listOf(TagIdDto(1L)),
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         whenever(contentService.updateContent(any(), any(), any(), any()))

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/service/ScheduleEventService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/service/ScheduleEventService.kt
@@ -133,7 +133,7 @@ class ScheduleEventService(
                 endDateTime = scheduleVo.endDateTime,
             ),
             getCurrentUserId = currentUserId,
-            contentAsignee = scheduleVo.contentAsignee,
+            contentAssignee = scheduleVo.contentAssignee,
         )
 
         applicationEventPublisher.publishEvent(
@@ -190,7 +190,7 @@ class ScheduleEventService(
                 updateTags(scheduleEvent.content, newTags)
             }
 
-            scheduleEvent.content.updatecontentAsignee(contentAsignee)
+            scheduleEvent.content.updateContentAssignee(contentAssignee)
 
             when (startDateTime) {
                 null -> scheduleEvent.convertToMemo(

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/vo/CreateScheduleVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/vo/CreateScheduleVo.kt
@@ -17,7 +17,7 @@ data class CreateScheduleVo(
     val endDateTime: LocalDateTime? = null,
     val endTimeZone: String? = null,
     val tagIds: Set<Long> = emptySet(),
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(
@@ -29,7 +29,7 @@ data class CreateScheduleVo(
             endDateTime: LocalDateTime? = null,
             endTimeZone: String? = null,
             tagIds: Set<Long> = emptySet(),
-            contentAsignee: ContentAssignee,
+            contentAssignee: ContentAssignee,
         ): CreateScheduleVo {
             return CreateScheduleVo(
                 title = title,
@@ -40,7 +40,7 @@ data class CreateScheduleVo(
                 endDateTime = endDateTime,
                 endTimeZone = endTimeZone,
                 tagIds = tagIds,
-                contentAsignee = contentAsignee,
+                contentAssignee = contentAssignee,
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/vo/ScheduleDetailVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/vo/ScheduleDetailVo.kt
@@ -15,7 +15,7 @@ data class ScheduleDetailVo(
     val parentScheduleId: Long? = null,
     val title: String?,
     val description: String?,
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(scheduleEvent: ScheduleEvent): ScheduleDetailVo {
@@ -28,7 +28,7 @@ data class ScheduleDetailVo(
                 isCompleted = scheduleEvent.content.contentDetail.isCompleted,
                 title = scheduleEvent.content.contentDetail.title,
                 description = scheduleEvent.content.contentDetail.description,
-                contentAsignee = scheduleEvent.content.contentAsignee,
+                contentAssignee = scheduleEvent.content.contentAssignee,
             )
         }
 
@@ -45,7 +45,7 @@ data class ScheduleDetailVo(
                 isCompleted = content.contentDetail.isCompleted,
                 title = content.contentDetail.title,
                 description = content.contentDetail.description,
-                contentAsignee = content.contentAsignee,
+                contentAssignee = content.contentAssignee,
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/vo/UpdateScheduleVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/vo/UpdateScheduleVo.kt
@@ -17,7 +17,7 @@ data class UpdateScheduleVo(
     val endDateTime: LocalDateTime? = null,
     val endTimeZone: String? = null,
     val tagIds: Set<Long> = emptySet(),
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(
@@ -30,7 +30,7 @@ data class UpdateScheduleVo(
             endDateTime: LocalDateTime? = null,
             endTimeZone: String? = null,
             tagIds: Set<Long> = emptySet(),
-            contentAsignee: ContentAssignee,
+            contentAssignee: ContentAssignee,
         ): UpdateScheduleVo {
             return UpdateScheduleVo(
                 selectedDate = selectedDate,
@@ -42,7 +42,7 @@ data class UpdateScheduleVo(
                 endDateTime = endDateTime,
                 endTimeZone = endTimeZone,
                 tagIds = tagIds,
-                contentAsignee = contentAsignee,
+                contentAssignee = contentAssignee,
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/model/Content.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/model/Content.kt
@@ -49,7 +49,7 @@ class Content(
 
     @Enumerated(EnumType.STRING)
     @Column(length = 50, nullable = false)
-    var contentAsignee: ContentAssignee = ContentAssignee.ME,
+    var contentAssignee: ContentAssignee = ContentAssignee.ME,
 ) : BaseEntity() {
     @Version
     private var version: Long = 0L
@@ -72,7 +72,7 @@ class Content(
         this.type = type
     }
 
-    fun updatecontentAsignee(contentAsignee: ContentAssignee) {
-        this.contentAsignee = contentAsignee
+    fun updateContentAssignee(contentAssignee: ContentAssignee) {
+        this.contentAssignee = contentAssignee
     }
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/service/ContentService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/service/ContentService.kt
@@ -123,7 +123,7 @@ class ContentService(
             isCompleted = contentRequestVo.isCompleted,
             tagIds = contentRequestVo.tags.toSet(),
             currentUserId = userId,
-            contentAsignee = contentRequestVo.contentAsignee
+            contentAssignee = contentRequestVo.contentAssignee
         )
 
         applicationEventPublisher.publishEvent(
@@ -169,7 +169,7 @@ class ContentService(
             isCompleted = requestVo.isCompleted
         )
         memo.updateContentDetail(newContentDetail)
-        memo.updatecontentAsignee(requestVo.contentAsignee)
+        memo.updateContentAssignee(requestVo.contentAssignee)
 
         updateTags(memo, requestVo.tagList.toSet())
         if (requestVo.dateTimeInfo == null) {  // 날짜 정보가 없다면 메모 업데이트만 진행
@@ -179,7 +179,7 @@ class ContentService(
             )
         }
 
-        memo.updatecontentAsignee(requestVo.contentAsignee)
+        memo.updateContentAssignee(requestVo.contentAssignee)
         
         val scheduleEvent = with(requestVo.dateTimeInfo) {
             ScheduleEvent.fromMemo(

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/service/MemoCreator.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/service/MemoCreator.kt
@@ -27,7 +27,7 @@ class MemoCreator(
         isCompleted: Boolean,
         tagIds: Set<Long>,
         currentUserId: Long,
-        contentAsignee: ContentAssignee,
+        contentAssignee: ContentAssignee,
     ): ContentVo {
         val contentDetail = ContentDetail(
             title = title,
@@ -40,7 +40,7 @@ class MemoCreator(
             user = user,
             contentDetail = contentDetail,
             type = ContentType.MEMO,
-            contentAsignee = contentAsignee
+            contentAssignee = contentAssignee
         )
 
         val savedContent = contentRepository.save(content)

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/service/ScheduleCreator.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/service/ScheduleCreator.kt
@@ -35,7 +35,7 @@ class ScheduleCreator(
         tagIds: Set<Long>,
         dateTimeInfo: DateTimeInfoVo,
         getCurrentUserId: Long,
-        contentAsignee: ContentAssignee,
+        contentAssignee: ContentAssignee,
     ): ScheduleEventVo {
         val contentDetail = ContentDetail(
             title = title,
@@ -49,7 +49,7 @@ class ScheduleCreator(
             user = user,
             contentDetail = contentDetail,
             type = ContentType.SCHEDULE,
-            contentAsignee = contentAsignee
+            contentAssignee = contentAssignee
         )
         val savedContent = contentRepository.save(content)
 

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/ContentResponseVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/ContentResponseVo.kt
@@ -12,7 +12,7 @@ data class ContentResponseVo(
     val isCompleted: Boolean,
     val tagList: List<TagVo>,
     val createdAt: LocalDate,
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(
@@ -26,7 +26,7 @@ data class ContentResponseVo(
                 isCompleted = content.contentDetail.isCompleted,
                 tagList = tagList,
                 createdAt = content.getCreatedAtInZone(KST_ZONE_ID).toLocalDate(),
-                contentAsignee = content.contentAsignee
+                contentAssignee = content.contentAssignee
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/ContentVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/ContentVo.kt
@@ -6,7 +6,7 @@ data class ContentVo(
     val id: Long,
     val contentDetail: ContentDetailVo,
     val type: ContentType,
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 ) {
     companion object {
         fun from(content: Content): ContentVo {
@@ -14,7 +14,7 @@ data class ContentVo(
                 id = content.id,
                 contentDetail = ContentDetailVo.from(content.contentDetail),
                 type = content.type,
-                contentAsignee = content.contentAsignee
+                contentAssignee = content.contentAssignee
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/CreateContentRequestVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/CreateContentRequestVo.kt
@@ -5,5 +5,5 @@ data class CreateContentRequestVo(
     val description: String?,
     val isCompleted: Boolean,
     val tags: List<Long>,
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 )

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/UpdateContentRequestVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/content/vo/UpdateContentRequestVo.kt
@@ -8,5 +8,5 @@ data class UpdateContentRequestVo(
     val isCompleted: Boolean,
     val tagList: List<Long>,
     val dateTimeInfo: DateTimeInfoVo?,
-    val contentAsignee: ContentAssignee,
+    val contentAssignee: ContentAssignee,
 )

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventCreateServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventCreateServiceTest.kt
@@ -92,7 +92,7 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
             endDateTime = NOW.plusDays(2),
             endTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -136,7 +136,7 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
             isCompleted = false,
             startDateTime = NOW,
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         // when, then
         val exception = assertThrows<ScheduleIllegalArgumentException> {
@@ -163,7 +163,7 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
             endDateTime = NOW.minusDays(1),
             endTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         // when, then
         val exception = assertThrows<ScheduleIllegalArgumentException> {
@@ -189,7 +189,7 @@ class ScheduleEventServiceCreateTest @Autowired constructor(
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
             endDateTime = NOW.plusDays(2),
             endTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventServiceOptimisticLockTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventServiceOptimisticLockTest.kt
@@ -110,7 +110,7 @@ class ScheduleEventServiceOptimisticLockTest @Autowired constructor(
             startTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
             endDateTime = NOW,
             endTimeZone = DateTimeUtil.UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         val threadCount = 2

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventServiceTest.kt
@@ -222,7 +222,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startTimeZone = startTimeZone?.id,
             endDateTime = NOW,
             endTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -272,7 +272,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startTimeZone = UTC_ZONE_ID.id,
             endDateTime = NOW,
             endTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when
@@ -320,7 +320,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             isCompleted = true,
             startDateTime = NOW.minusDays(2),
             startTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when
@@ -363,7 +363,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             isCompleted = true,
             startDateTime = NOW.minusDays(2),
             startTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when, then
@@ -409,7 +409,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             isCompleted = true,
             startDateTime = NOW.minusDays(2),
             startTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when, then
@@ -450,7 +450,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startTimeZone = UTC_ZONE_ID.id,
             endDateTime = NOW.minusDays(1),  // 유효하지 않은 endDateTime.
             endTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when, then
@@ -496,7 +496,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             isCompleted = false,
             startDateTime = NOW.plusDays(1),
             startTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when, then
@@ -539,7 +539,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             isCompleted = false,
             startDateTime = NOW.plusDays(1),
             startTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
 
         // when, then
@@ -590,7 +590,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startDateTime = NOW.plusDays(1),
             startTimeZone = UTC_ZONE_ID.id,
             tagIds = newTagIds,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -642,7 +642,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startDateTime = NOW.plusDays(1),
             startTimeZone = UTC_ZONE_ID.id,
             tagIds = newTags.map { it.id }.toSet(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -690,7 +690,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startDateTime = NOW.plusDays(1),
             startTimeZone = UTC_ZONE_ID.id,
             tagIds = newTags.map { it.id }.toSet(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -739,7 +739,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startDateTime = NOW.plusDays(1),
             startTimeZone = UTC_ZONE_ID.id,
             tagIds = sameTagIds,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -781,7 +781,7 @@ class ScheduleEventServiceTest @Autowired constructor(
             startTimeZone = null,
             endDateTime = NOW,
             endTimeZone = UTC_ZONE_ID.id,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -1150,7 +1150,7 @@ class ScheduleEventServiceTest @Autowired constructor(
                     selectedDate = DateTimeUtil.localNow().toLocalDate(),
                     title = "test-title",
                     isCompleted = false,
-                    contentAsignee = ContentAssignee.ME,
+                    contentAssignee = ContentAssignee.ME,
                 ),
             )
         }

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/ContentServiceRetryableTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/ContentServiceRetryableTest.kt
@@ -55,7 +55,7 @@ class ContentServiceRetryableTest {
             isCompleted = false,
             tagList = listOf(),
             dateTimeInfo = null,
-            contentAsignee = ContentAssignee.ME
+            contentAssignee = ContentAssignee.ME
         )
         val user = createTestUser(id = userId)
         val memo = createTestContent(

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/ContentServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/ContentServiceTest.kt
@@ -111,7 +111,7 @@ class ContentServiceTest @Autowired constructor(
             description = "test-desc",
             isCompleted = false,
             tags = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -140,7 +140,7 @@ class ContentServiceTest @Autowired constructor(
             description = null,
             isCompleted = false,
             tags = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -176,7 +176,7 @@ class ContentServiceTest @Autowired constructor(
             description = description,
             isCompleted = false,
             tags = emptyList(),
-            contentAsignee = ContentAssignee.PARTNER,
+            contentAssignee = ContentAssignee.PARTNER,
         )
 
         // when
@@ -202,7 +202,7 @@ class ContentServiceTest @Autowired constructor(
             description = null,
             isCompleted = false,
             tags = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -228,7 +228,7 @@ class ContentServiceTest @Autowired constructor(
             description = "test-desc",
             isCompleted = false,
             tags = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -354,7 +354,7 @@ class ContentServiceTest @Autowired constructor(
             isCompleted = newCompleted,
             tagList = emptyList(),
             dateTimeInfo = null, // Keep as MEMO
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -390,7 +390,7 @@ class ContentServiceTest @Autowired constructor(
             isCompleted = memo.contentDetail.isCompleted,
             tagList = listOf(tag2.id, tag3.id),
             dateTimeInfo = null,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -424,7 +424,7 @@ class ContentServiceTest @Autowired constructor(
             isCompleted = false,
             tagList = emptyList(),
             dateTimeInfo = null,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when & then
@@ -454,7 +454,7 @@ class ContentServiceTest @Autowired constructor(
                 startTimezone = DateTimeUtil.KST_ZONE_ID.toString(),
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/ContentServiceUnitTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/ContentServiceUnitTest.kt
@@ -425,7 +425,7 @@ class ContentServiceUnitTest {
             description = "b",
             isCompleted = false,
             tags = listOf(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         every { coupleRepository.findByIdWithMembers(any()) } returns null
 
@@ -452,7 +452,7 @@ class ContentServiceUnitTest {
             isCompleted = false,
             tagList = listOf(),
             dateTimeInfo = null,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         val memo = createTestContent(
             id = memoId,
@@ -494,7 +494,7 @@ class ContentServiceUnitTest {
             isCompleted = false,
             tagList = listOf(),
             dateTimeInfo = null,
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         val user = createTestUser(id = userId)
         val user2 = createTestUser(id = user2Id)

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/MemoToScheduleConvertTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/content/service/MemoToScheduleConvertTest.kt
@@ -84,7 +84,7 @@ class MemoToScheduleConvertTest @Autowired constructor(
                 endTimezone = DateTimeUtil.UTC_ZONE_ID.id,
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when
@@ -120,7 +120,7 @@ class MemoToScheduleConvertTest @Autowired constructor(
                 startTimezone = DateTimeUtil.UTC_ZONE_ID.id,
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         val invalidMemoId = 0L // 존재하지 않는 ID
 
@@ -151,7 +151,7 @@ class MemoToScheduleConvertTest @Autowired constructor(
                 startTimezone = DateTimeUtil.UTC_ZONE_ID.id,
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         // when, then
         val exception = assertThrows<ContentNotFoundException> {
@@ -182,7 +182,7 @@ class MemoToScheduleConvertTest @Autowired constructor(
                 startTimezone = DateTimeUtil.UTC_ZONE_ID.id,
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         // when, then
         val exception = assertThrows<ContentAccessDeniedException> {
@@ -218,7 +218,7 @@ class MemoToScheduleConvertTest @Autowired constructor(
                 startTimezone = DateTimeUtil.UTC_ZONE_ID.id,
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
 
         // when, then
@@ -250,7 +250,7 @@ class MemoToScheduleConvertTest @Autowired constructor(
                 endTimezone = DateTimeUtil.UTC_ZONE_ID.id
             ),
             tagList = emptyList(),
-            contentAsignee = ContentAssignee.ME,
+            contentAssignee = ContentAssignee.ME,
         )
         // when, then
         val exception = assertThrows<ScheduleIllegalArgumentException> {


### PR DESCRIPTION
## 관련 이슈
- close #235 

## 작업한 내용
- asinee -> assinee로 철자 오류를 수정했습니다.
- 구버전 api와 호환성을 위한 contentAssinee의 Default값을 `ME`로 추가했습니다.

## PR 포인트
- 부득이하게 어푸 없이 dev에 강제로 머지하겠습니다..!