### PR TITLE
[Refactor] 일정 조회 api의 userTimeZone 제거

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/controller/CalendarController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/controller/CalendarController.kt
@@ -50,7 +50,6 @@ class CalendarController(
         val scheduleDetailsVo = scheduleEventService.getSchedules(
             startDate = queryParameter.startDate,
             endDate = queryParameter.endDate,
-            userTimeZone = queryParameter.userTimeZone,
             currentUserCoupleId = getCurrentUserCoupleId(),
             requestUserId = getCurrentUserId(),
         )

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/controller/dto/request/GetCalendarQueryParameter.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/controller/dto/request/GetCalendarQueryParameter.kt
@@ -23,11 +23,4 @@ data class GetCalendarQueryParameter(
         example = "2025-03-31",
     )
     val endDate: LocalDate,
-
-    @field:Parameter(
-        description = "유저의 현재 타임존",
-        `in` = ParameterIn.QUERY,
-        example = "Asia/Seoul",
-    )
-    val userTimeZone: String = ZoneId.of("Asia/Seoul").id,
 )

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/ScheduleController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/calendarevent/scheduleevent/controller/ScheduleController.kt
@@ -51,7 +51,6 @@ class ScheduleController(
         val scheduleDetailsVo = scheduleEventService.getSchedules(
             startDate = queryParameter.startDate,
             endDate = queryParameter.endDate,
-            userTimeZone = queryParameter.userTimeZone,
             currentUserCoupleId = getCurrentUserCoupleId(),
             requestUserId = getCurrentUserId(),
         )

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/service/ScheduleEventService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/service/ScheduleEventService.kt
@@ -83,7 +83,6 @@ class ScheduleEventService(
     fun getSchedules(
         startDate: LocalDate,
         endDate: LocalDate,
-        userTimeZone: String,
         currentUserCoupleId: Long,
         requestUserId: Long,
     ): ScheduleDetailsVo {

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/calendarevent/scheduleevent/service/ScheduleEventServiceTest.kt
@@ -916,7 +916,6 @@ class ScheduleEventServiceTest @Autowired constructor(
         val scheduleDetailVoList = scheduleEventService.getSchedules(
             startDate = startDate,
             endDate = endDate,
-            userTimeZone = userTimeZone.id,
             currentUserCoupleId = myUser.couple?.id ?: error("couple id가 없습니다"),
             requestUserId = myUser.id,
         ).scheduleDetailVoList
@@ -961,14 +960,12 @@ class ScheduleEventServiceTest @Autowired constructor(
         val resultDaily = scheduleEventService.getSchedules(
             startDate = startDate,
             endDate = startDate,
-            userTimeZone = userTimeZone.id,
             currentUserCoupleId = myUser.couple?.id ?: error("couple id가 없습니다"),
             requestUserId = myUser.id,
         ).scheduleDetailVoList
         val resultWeekly = scheduleEventService.getSchedules(
             startDate = startDate,
             endDate = startDate.plusDays(6),
-            userTimeZone = userTimeZone.id,
             currentUserCoupleId = myUser.couple?.id ?: error("couple id가 없습니다"),
             requestUserId = myUser.id,
         ).scheduleDetailVoList
@@ -1002,7 +999,6 @@ class ScheduleEventServiceTest @Autowired constructor(
         val result = scheduleEventService.getSchedules(
             startDate = startDate.minusDays(1),
             endDate = startDate.minusDays(1),
-            userTimeZone = userTimeZone.id,
             currentUserCoupleId = myUser.couple?.id ?: error("couple id가 없습니다"),
             requestUserId = myUser.id,
         ).scheduleDetailVoList
@@ -1043,7 +1039,6 @@ class ScheduleEventServiceTest @Autowired constructor(
         val result = scheduleEventService.getSchedules(
             startDate = startDate,
             endDate = startDate.plusDays(1),
-            userTimeZone = userTimeZone.id,
             currentUserCoupleId = myUser.couple?.id ?: error("couple id가 없습니다"),
             requestUserId = myUser.id,
         ).scheduleDetailVoList
@@ -1076,7 +1071,6 @@ class ScheduleEventServiceTest @Autowired constructor(
             scheduleEventService.getSchedules(
                 startDate = startDate.minusDays(1),
                 endDate = startDate.minusDays(1),
-                userTimeZone = userTimeZone.id,
                 currentUserCoupleId = 0L,  // Invalid couple id
                 requestUserId = myUser.id,
             )
@@ -1111,7 +1105,6 @@ class ScheduleEventServiceTest @Autowired constructor(
             scheduleEventService.getSchedules(
                 startDate = startDate.minusDays(1),
                 endDate = startDate.minusDays(1),
-                userTimeZone = userTimeZone.id,
                 currentUserCoupleId = couple.id,
                 requestUserId = myUser.id,
             )


### PR DESCRIPTION
## 관련 이슈
- close #247 

## 작업한 내용
- 일정 조회에 사용되지 않는 불필요 timezone request parameter 제거

## PR 포인트
- 일정 검색 시 활용이 되지 않을것 같아 클라이언트측과 상의 후 제거합니다!