### PR TITLE
[Feat] 강제 업데이트를 위한 클라이언트 버전 체크 API 추가

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
@@ -13,6 +13,9 @@ import com.whatever.caramel.domain.clientversion.vo.ForceUpdate
 import com.whatever.caramel.domain.clientversion.vo.NoUpdate
 import com.whatever.caramel.domain.clientversion.vo.RecommendUpdate
 import com.whatever.caramel.domain.clientversion.vo.VersionPolicyVo
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -21,6 +24,10 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(
+    name = "클라이언트 버전 API",
+    description = "클라이언트 버전 체크 등 관련 기능을 제공하는 API"
+)
 @RestController
 @RequestMapping("/v1/client-versions")
 class ClientVersionController(
@@ -32,6 +39,15 @@ class ClientVersionController(
     private lateinit var iosStoreUri: String
 
     @DisableSwaggerAuthButton
+    @Operation(
+        summary = "강제 업데이트 필요 여부 조회",
+        description = """
+            ### 전송한 버전을 기준으로, 강제 업데이트가 필요한지 조회합니다.
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "강제 업데이트 필요 여부, store uri"),
+        ]
+    )
     @GetMapping("/update-policy")
     fun getUpdatePolicy(
         @RequestHeader(name = CaramelHttpHeaders.OS_TYPE) osType: OsType,

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
@@ -1,0 +1,54 @@
+package com.whatever.caramel.api.clientversion.controller
+
+import com.whatever.caramel.api.clientversion.controller.dto.GetUpdatePolicyResponse
+import com.whatever.caramel.common.response.CaramelApiResponse
+import com.whatever.caramel.common.response.succeed
+import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.model.OsType.ANDROID
+import com.whatever.caramel.domain.clientversion.model.OsType.IOS
+import com.whatever.caramel.domain.clientversion.service.ClientVersionService
+import com.whatever.caramel.domain.clientversion.vo.ForceUpdate
+import com.whatever.caramel.domain.clientversion.vo.NoUpdate
+import com.whatever.caramel.domain.clientversion.vo.RecommendUpdate
+import com.whatever.caramel.domain.clientversion.vo.VersionPolicyVo
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/client-versions")
+class ClientVersionController(
+    private val clientVersionService: ClientVersionService,
+) {
+    @Value("\${app-store.android-uri}")
+    private lateinit var androidStoreUri: String
+    @Value("\${app-store.ios-uri}")
+    private lateinit var iosStoreUri: String
+
+    @GetMapping("/{osType}/update-policy")
+    fun getUpdatePolicy(
+        @PathVariable osType: OsType,
+        @RequestParam currentVersionCode: Int,
+    ): CaramelApiResponse<GetUpdatePolicyResponse> {
+        val versionPolicyVo = clientVersionService.checkVersion(osType, currentVersionCode)
+
+        return versionPolicyVo.toResponse(iosStoreUri, androidStoreUri).succeed()
+    }
+}
+
+private fun VersionPolicyVo.toResponse(androidStoreUri: String, iosStoreUri: String): GetUpdatePolicyResponse {
+    fun OsType.getStoreUri(): String {
+        return when (this) {
+            ANDROID -> androidStoreUri
+            IOS -> iosStoreUri
+        }
+    }
+    return when (this) {
+        is ForceUpdate -> GetUpdatePolicyResponse(forceUpdate = true, storeUri = osType.getStoreUri())
+        is RecommendUpdate -> GetUpdatePolicyResponse(forceUpdate = false, storeUri = osType.getStoreUri())
+        is NoUpdate -> GetUpdatePolicyResponse(forceUpdate = false)
+    }
+}

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
@@ -2,6 +2,7 @@ package com.whatever.caramel.api.clientversion.controller
 
 import com.whatever.caramel.api.clientversion.controller.dto.GetUpdatePolicyResponse
 import com.whatever.caramel.common.global.annotation.DisableSwaggerAuthButton
+import com.whatever.caramel.common.global.constants.CaramelHttpHeaders
 import com.whatever.caramel.common.response.CaramelApiResponse
 import com.whatever.caramel.common.response.succeed
 import com.whatever.caramel.domain.clientversion.model.OsType
@@ -15,6 +16,7 @@ import com.whatever.caramel.domain.clientversion.vo.VersionPolicyVo
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -30,14 +32,17 @@ class ClientVersionController(
     private lateinit var iosStoreUri: String
 
     @DisableSwaggerAuthButton
-    @GetMapping("/{osType}/update-policy")
+    @GetMapping("/update-policy")
     fun getUpdatePolicy(
-        @PathVariable osType: OsType,
+        @RequestHeader(name = CaramelHttpHeaders.OS_TYPE) osType: OsType,
         @RequestParam currentVersionCode: Int,
     ): CaramelApiResponse<GetUpdatePolicyResponse> {
         val versionPolicyVo = clientVersionService.checkVersion(osType, currentVersionCode)
 
-        return versionPolicyVo.toResponse(iosStoreUri, androidStoreUri).succeed()
+        return versionPolicyVo.toResponse(
+            androidStoreUri = androidStoreUri,
+            iosStoreUri = iosStoreUri,
+        ).succeed()
     }
 }
 
@@ -50,7 +55,7 @@ private fun VersionPolicyVo.toResponse(androidStoreUri: String, iosStoreUri: Str
     }
     return when (this) {
         is ForceUpdate -> GetUpdatePolicyResponse(forceUpdate = true, storeUri = osType.getStoreUri())
-        is RecommendUpdate -> GetUpdatePolicyResponse(forceUpdate = false, storeUri = osType.getStoreUri())
+        is RecommendUpdate -> GetUpdatePolicyResponse(forceUpdate = false)
         is NoUpdate -> GetUpdatePolicyResponse(forceUpdate = false)
     }
 }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
@@ -18,7 +18,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -34,9 +33,9 @@ class ClientVersionController(
     private val clientVersionService: ClientVersionService,
 ) {
     @Value("\${app-store.android-uri}")
-    private lateinit var androidStoreUri: String
+    private lateinit var androidUpdateUri: String
     @Value("\${app-store.ios-uri}")
-    private lateinit var iosStoreUri: String
+    private lateinit var iosUpdateUri: String
 
     @DisableSwaggerAuthButton
     @Operation(
@@ -56,21 +55,21 @@ class ClientVersionController(
         val versionPolicyVo = clientVersionService.checkVersion(osType, currentVersionCode)
 
         return versionPolicyVo.toResponse(
-            androidStoreUri = androidStoreUri,
-            iosStoreUri = iosStoreUri,
+            androidUpdateUri = androidUpdateUri,
+            iosUpdateUri = iosUpdateUri,
         ).succeed()
     }
 }
 
-private fun VersionPolicyVo.toResponse(androidStoreUri: String, iosStoreUri: String): GetUpdatePolicyResponse {
-    fun OsType.getStoreUri(): String {
+private fun VersionPolicyVo.toResponse(androidUpdateUri: String, iosUpdateUri: String): GetUpdatePolicyResponse {
+    fun OsType.getUpdateUri(): String {
         return when (this) {
-            ANDROID -> androidStoreUri
-            IOS -> iosStoreUri
+            ANDROID -> androidUpdateUri
+            IOS -> iosUpdateUri
         }
     }
     return when (this) {
-        is ForceUpdate -> GetUpdatePolicyResponse(forceUpdate = true, storeUri = osType.getStoreUri())
+        is ForceUpdate -> GetUpdatePolicyResponse(forceUpdate = true, updateUri = osType.getUpdateUri())
         is RecommendUpdate -> GetUpdatePolicyResponse(forceUpdate = false)
         is NoUpdate -> GetUpdatePolicyResponse(forceUpdate = false)
     }

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/ClientVersionController.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.api.clientversion.controller
 
 import com.whatever.caramel.api.clientversion.controller.dto.GetUpdatePolicyResponse
+import com.whatever.caramel.common.global.annotation.DisableSwaggerAuthButton
 import com.whatever.caramel.common.response.CaramelApiResponse
 import com.whatever.caramel.common.response.succeed
 import com.whatever.caramel.domain.clientversion.model.OsType
@@ -28,6 +29,7 @@ class ClientVersionController(
     @Value("\${app-store.ios-uri}")
     private lateinit var iosStoreUri: String
 
+    @DisableSwaggerAuthButton
     @GetMapping("/{osType}/update-policy")
     fun getUpdatePolicy(
         @PathVariable osType: OsType,

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/dto/GetUpdatePolicyResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/dto/GetUpdatePolicyResponse.kt
@@ -1,0 +1,6 @@
+package com.whatever.caramel.api.clientversion.controller.dto
+
+data class GetUpdatePolicyResponse(
+    val forceUpdate: Boolean,
+    val storeUri: String? = null,
+)

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/dto/GetUpdatePolicyResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/clientversion/controller/dto/GetUpdatePolicyResponse.kt
@@ -2,5 +2,5 @@ package com.whatever.caramel.api.clientversion.controller.dto
 
 data class GetUpdatePolicyResponse(
     val forceUpdate: Boolean,
-    val storeUri: String? = null,
+    val updateUri: String? = null,
 )

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/config/SecurityConfig.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/config/SecurityConfig.kt
@@ -95,6 +95,7 @@ class SecurityConfig(
                 authorize(HttpMethod.POST, "/v1/auth/refresh", permitAll)
                 authorize("/sample/**", permitAll)
                 authorize("${actuatorPath}/**", permitAll)
+                authorize("/v1/client-versions/**", permitAll)
 
                 // 2. Role: NEW
                 authorize(HttpMethod.POST, "/v1/user/profile", hasAnyRole(NEW.name))

--- a/caramel-api/src/main/resources/application.yaml
+++ b/caramel-api/src/main/resources/application.yaml
@@ -102,6 +102,10 @@ crypto:
   password: ${CRYPTO_PASSWORD}
   salt: ${CRYPTO_SALT}
 
+app-store:
+  android-uri: https://play.google.com/store/apps/details?id=com.whatever.caramel&hl=ko
+  ios-uri: https://apps.apple.com/kr/app/%EC%B9%B4%EB%9D%BC%EB%A9%9C-caramel-%EC%9A%B0%EB%A6%AC%EB%A7%8C%EC%9D%98-%EA%B0%90%EC%84%B1-%EC%BB%A4%ED%94%8C-%EB%8B%A4%EC%9D%B4%EC%96%B4%EB%A6%AC/id6745321351
+
 ---
 # ┌──────────────────────────── Production 프로파일 ──────────────────────────
 spring:

--- a/caramel-common/src/main/kotlin/com/whatever/caramel/common/global/constants/CaramelHttpHeader.kt
+++ b/caramel-common/src/main/kotlin/com/whatever/caramel/common/global/constants/CaramelHttpHeader.kt
@@ -4,10 +4,12 @@ object CaramelHttpHeaders {
     const val TIME_ZONE = "Time-Zone"
     const val AUTH_JWT_HEADER = "Authorization"
     const val DEVICE_ID = "Device-Id"
+    const val OS_TYPE = "Os-Type"
 
     val ALL_HEADERS = setOf(
         TIME_ZONE,
         AUTH_JWT_HEADER,
         DEVICE_ID,
+        OS_TYPE,
     )
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/config/CacheConfig.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/config/CacheConfig.kt
@@ -50,6 +50,6 @@ enum class CacheType(
     val cacheName: String,
     val ttl: Duration = Duration.ofDays(7L),
 ) {
-    OIDC_PUBLIC_KEY("oidc-public-key"),
-    CLIENT_VERSIONS("client-versions"),
+    OIDC_PUBLIC_KEY("auth:oidc-public-key"),
+    CLIENT_VERSIONS("app:client-versions"),
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/config/CacheConfig.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/config/CacheConfig.kt
@@ -1,5 +1,10 @@
 package com.whatever.caramel.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -17,9 +22,16 @@ import java.time.Duration
 class RedisCacheConfig {
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val ptv = BasicPolymorphicTypeValidator.builder().allowIfBaseType(Any::class.java).build()
+        val customObjectMapper = jacksonObjectMapper()
+            .registerModule(KotlinModule.Builder().build())
+            .registerModule(JavaTimeModule())
+            .activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.EVERYTHING)
+
+
         val keySerializationPair = RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
         val valueSerializationPair =
-            RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer())
+            RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer(customObjectMapper))
         val baseConfig = RedisCacheConfiguration.defaultCacheConfig()
             .serializeKeysWith(keySerializationPair)
             .serializeValuesWith(valueSerializationPair)

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/config/CacheConfig.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/config/CacheConfig.kt
@@ -1,6 +1,5 @@
 package com.whatever.caramel.config
 
-import com.whatever.caramel.domain.user.model.LoginPlatform
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
@@ -16,21 +15,21 @@ import java.time.Duration
 @EnableCaching
 @Configuration
 class RedisCacheConfig {
-
-    @Bean(name = ["oidcCacheManager"])
-    fun oidcCacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
-        val stringSerializationPair =
-            RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
-        val jsonSerializerPair =
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val keySerializationPair = RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer())
+        val valueSerializationPair =
             RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer())
+        val baseConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(keySerializationPair)
+            .serializeValuesWith(valueSerializationPair)
 
-        val redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-            .serializeKeysWith(stringSerializationPair)
-            .serializeValuesWith(jsonSerializerPair)
-            .entryTtl(CacheType.OIDC_PUBLIC_KEY.ttl)
+        val cacheConfigurations = CacheType.entries.associate { cacheType ->
+            cacheType.cacheName to baseConfig.entryTtl(cacheType.ttl)
+        }
 
         return RedisCacheManager.builder(redisConnectionFactory)
-            .cacheDefaults(redisCacheConfiguration)
+            .withInitialCacheConfigurations(cacheConfigurations)
             .build()
     }
 }
@@ -38,7 +37,7 @@ class RedisCacheConfig {
 enum class CacheType(
     val cacheName: String,
     val ttl: Duration = Duration.ofDays(7L),
-    val maximumSize: Long = LoginPlatform.entries.size.toLong(),
 ) {
-    OIDC_PUBLIC_KEY("oidc"),
+    OIDC_PUBLIC_KEY("oidc-public-key"),
+    CLIENT_VERSIONS("client-versions"),
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
@@ -5,6 +5,7 @@ import com.whatever.caramel.common.global.jwt.JwtHelper
 import com.whatever.caramel.common.global.jwt.JwtHelper.Companion.BEARER_TYPE
 import com.whatever.caramel.common.global.jwt.JwtProperties
 import com.whatever.caramel.common.util.DateTimeUtil
+import com.whatever.caramel.config.CacheType
 import com.whatever.caramel.domain.auth.exception.AuthException
 import com.whatever.caramel.domain.auth.exception.AuthExceptionCode
 import com.whatever.caramel.domain.auth.exception.AuthExceptionCode.USER_PROVIDER_NOT_FOUND
@@ -165,7 +166,7 @@ class AuthService(
 }
 
 private fun CacheManager.evictOidcPublicKeyCache(loginPlatform: LoginPlatform) {
-    val cache = getCache("oidc-public-key")
+    val cache = getCache(CacheType.OIDC_PUBLIC_KEY.cacheName)
     if (cache == null) {
         logger.debug { "Cache 'oidc-public-key' not available. Skipping eviction for ${loginPlatform.name}." }
         return

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
@@ -23,7 +23,6 @@ import com.whatever.caramel.domain.user.model.LoginPlatform
 import com.whatever.caramel.domain.user.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.jsonwebtoken.ExpiredJwtException
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -36,7 +35,7 @@ class AuthService(
     private val jwtProperties: JwtProperties,
     private val authRedisRepository: AuthRedisRepository,
     userProviders: List<SocialUserProvider>,
-    @Qualifier("oidcCacheManager") private val oidcCacheManager: CacheManager,
+    private val oidcCacheManager: CacheManager,
     private val userRepository: UserRepository,
     private val coupleService: CoupleService,
 ) {

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/ClientVersion.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/ClientVersion.kt
@@ -10,7 +10,9 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.PositiveOrZero
 
 @Entity
 @Table(
@@ -29,15 +31,22 @@ class ClientVersion(
 
     @Column(nullable = false)
     @field:Min(value = 10)  // client의 major 버전이 10으로 시작
+    @field:Max(value = 99)
     val major: Int,
 
     @Column(nullable = false)
+    @field:PositiveOrZero
+    @field:Max(value = 99)
     val minor: Int,
 
     @Column(nullable = false)
+    @field:PositiveOrZero
+    @field:Max(value = 99)
     val patch: Int,
 
     @Column(nullable = false)
+    @field:PositiveOrZero
+    @field:Max(value = 99)
     val build: Int,
 
     @Column(length = 100)

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/ClientVersion.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/ClientVersion.kt
@@ -1,0 +1,55 @@
+package com.whatever.caramel.domain.clientversion.model
+
+import com.whatever.caramel.domain.base.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import jakarta.validation.constraints.Min
+
+@Entity
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "client_version_unique_os_type_and_code",
+            columnNames = ["os_type", "code"],
+
+        )
+    ]
+)
+class ClientVersion(
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val osType: OsType,
+
+    @Column(nullable = false)
+    @field:Min(value = 10)  // client의 major 버전이 10으로 시작
+    val major: Int,
+
+    @Column(nullable = false)
+    val minor: Int,
+
+    @Column(nullable = false)
+    val patch: Int,
+
+    @Column(nullable = false)
+    val build: Int,
+
+    @Column(nullable = false)
+    val isMinimum: Boolean = false,
+
+    @Column(length = 100)
+    val releaseNote: String? = null,
+) : BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L
+
+    @Column(nullable = false)
+    val code: Int = major * 1_00_00_00 + minor * 1_00_00 + patch * 1_00 + build
+}

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/ClientVersion.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/ClientVersion.kt
@@ -40,9 +40,6 @@ class ClientVersion(
     @Column(nullable = false)
     val build: Int,
 
-    @Column(nullable = false)
-    val isMinimum: Boolean = false,
-
     @Column(length = 100)
     val releaseNote: String? = null,
 ) : BaseTimeEntity() {

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/OsType.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/OsType.kt
@@ -1,0 +1,6 @@
+package com.whatever.caramel.domain.clientversion.model
+
+enum class OsType {
+    ANDROID,
+    IOS,
+}

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/OsVersionPolicy.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/model/OsVersionPolicy.kt
@@ -1,0 +1,26 @@
+package com.whatever.caramel.domain.clientversion.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class OsVersionPolicy(
+    @Id
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    val osType: OsType,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "minimum_version_id", nullable = false)
+    var minimumVersion: ClientVersion,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recommended_version_id")
+    var recommendedVersion: ClientVersion?,
+)

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/repository/ClientVersionRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/repository/ClientVersionRepository.kt
@@ -15,13 +15,4 @@ interface ClientVersionRepository : JpaRepository<ClientVersion, Long> {
     """
     )
     fun findLatestVersionByOsType(osType: OsType): ClientVersion?
-
-    @Query(
-        """
-        select cv from ClientVersion cv
-        where cv.isMinimum = true and cv.osType = :osType
-        order by cv.code desc limit 1
-    """
-    )
-    fun findMinimumVersionByOsType(osType: OsType): ClientVersion?
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/repository/ClientVersionRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/repository/ClientVersionRepository.kt
@@ -1,0 +1,27 @@
+package com.whatever.caramel.domain.clientversion.repository
+
+import com.whatever.caramel.domain.clientversion.model.ClientVersion
+import com.whatever.caramel.domain.clientversion.model.OsType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface ClientVersionRepository : JpaRepository<ClientVersion, Long> {
+
+    @Query(
+        """
+        select cv from ClientVersion cv
+        where cv.osType = :osType
+        order by cv.code desc limit 1
+    """
+    )
+    fun findLatestVersionByOsType(osType: OsType): ClientVersion?
+
+    @Query(
+        """
+        select cv from ClientVersion cv
+        where cv.isMinimum = true and cv.osType = :osType
+        order by cv.code desc limit 1
+    """
+    )
+    fun findMinimumVersionByOsType(osType: OsType): ClientVersion?
+}

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/repository/OsVersionPolicyRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/repository/OsVersionPolicyRepository.kt
@@ -1,0 +1,7 @@
+package com.whatever.caramel.domain.clientversion.repository
+
+import com.whatever.caramel.domain.clientversion.model.OsVersionPolicy
+import com.whatever.caramel.domain.clientversion.model.OsType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface OsVersionPolicyRepository : JpaRepository<OsVersionPolicy, OsType>

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheService.kt
@@ -1,15 +1,18 @@
 package com.whatever.caramel.domain.clientversion.service
 
 import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.repository.OsVersionPolicyRepository
 import com.whatever.caramel.domain.clientversion.repository.ClientVersionRepository
 import com.whatever.caramel.domain.clientversion.vo.SupportedVersionsVo
 import com.whatever.caramel.domain.clientversion.vo.ClientVersionVo
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
 class ClientVersionCacheService(
     private val clientVersionRepository: ClientVersionRepository,
+    private val osVersionPolicyRepository: OsVersionPolicyRepository,
 ) {
     @Cacheable(
         cacheNames = ["app:client-versions"],
@@ -18,14 +21,12 @@ class ClientVersionCacheService(
     )
     fun getActiveVersions(osType: OsType): SupportedVersionsVo {
         val latestVersion = clientVersionRepository.findLatestVersionByOsType(osType)
-        val minimumVersion = latestVersion?.let { latestVersion ->
-            if (latestVersion.isMinimum) latestVersion
-            else clientVersionRepository.findMinimumVersionByOsType(osType)
-        }
+        val policy = osVersionPolicyRepository.findByIdOrNull(osType)
 
         return SupportedVersionsVo(
             latest = latestVersion?.let { ClientVersionVo.from(latestVersion) },
-            minimum = minimumVersion?.let { ClientVersionVo.from(minimumVersion) },
+            recommended = policy?.recommendedVersion?.let { ClientVersionVo.from(it) },
+            minimum = policy?.let { ClientVersionVo.from(it.minimumVersion) },
         )
     }
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheService.kt
@@ -12,7 +12,7 @@ class ClientVersionCacheService(
     private val clientVersionRepository: ClientVersionRepository,
 ) {
     @Cacheable(
-        cacheNames = ["client-versions"],
+        cacheNames = ["app:client-versions"],
         key = "#osType",
         unless = "#result.latest == null",
     )

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheService.kt
@@ -1,0 +1,31 @@
+package com.whatever.caramel.domain.clientversion.service
+
+import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.repository.ClientVersionRepository
+import com.whatever.caramel.domain.clientversion.vo.SupportedVersionsVo
+import com.whatever.caramel.domain.clientversion.vo.ClientVersionVo
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+
+@Service
+class ClientVersionCacheService(
+    private val clientVersionRepository: ClientVersionRepository,
+) {
+    @Cacheable(
+        cacheNames = ["client-versions"],
+        key = "#osType",
+        unless = "#result.latest == null",
+    )
+    fun getActiveVersions(osType: OsType): SupportedVersionsVo {
+        val latestVersion = clientVersionRepository.findLatestVersionByOsType(osType)
+        val minimumVersion = latestVersion?.let { latestVersion ->
+            if (latestVersion.isMinimum) latestVersion
+            else clientVersionRepository.findMinimumVersionByOsType(osType)
+        }
+
+        return SupportedVersionsVo(
+            latest = latestVersion?.let { ClientVersionVo.from(latestVersion) },
+            minimum = minimumVersion?.let { ClientVersionVo.from(minimumVersion) },
+        )
+    }
+}

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
@@ -17,12 +17,8 @@ class ClientVersionService(
     fun checkVersion(osType: OsType, versionCode: Int): VersionPolicyVo {
 
         val (latestVersion, minimumVersion) = clientVersionCacheService.getActiveVersions(osType)
-        if (latestVersion == null) {
-            logger.warn { "Failed to find LATEST client version for osType: ${osType}" }
-            return NoUpdate
-        }
-        if (minimumVersion == null) {
-            logger.warn { "Failed to find MINIMUM client version for osType: ${osType}" }
+        if (latestVersion == null || minimumVersion == null) {
+            logger.warn { "Failed to find valid client version(Latest or Minimum) for osType: ${osType}" }
             return NoUpdate
         }
 

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
@@ -15,7 +15,6 @@ class ClientVersionService(
     private val clientVersionCacheService: ClientVersionCacheService,
 ) {
     fun checkVersion(osType: OsType, versionCode: Int): VersionPolicyVo {
-
         val (latestVersion, recommendedVersion, minimumVersion) = clientVersionCacheService.getActiveVersions(osType)
         if (latestVersion == null || minimumVersion == null) {
             logger.warn { "Failed to find valid client version(Latest or Minimum) for osType: ${osType}" }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
@@ -1,0 +1,43 @@
+package com.whatever.caramel.domain.clientversion.service
+
+import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.vo.ForceUpdate
+import com.whatever.caramel.domain.clientversion.vo.NoUpdate
+import com.whatever.caramel.domain.clientversion.vo.RecommendUpdate
+import com.whatever.caramel.domain.clientversion.vo.VersionPolicyVo
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger { }
+
+@Service
+class ClientVersionService(
+    private val clientVersionCacheService: ClientVersionCacheService,
+) {
+    fun checkVersion(osType: OsType, versionCode: Int): VersionPolicyVo {
+
+        val (latestVersion, minimumVersion) = clientVersionCacheService.getActiveVersions(osType)
+        if (latestVersion == null) {
+            logger.warn { "Failed to find LATEST client version for osType: ${osType}" }
+            return NoUpdate
+        }
+        if (minimumVersion == null) {
+            logger.warn { "Failed to find MINIMUM client version for osType: ${osType}" }
+            return NoUpdate
+        }
+
+        return when {
+            versionCode < minimumVersion.code -> ForceUpdate(
+                latestVersionCode = latestVersion.code,
+                osType = osType
+            )
+
+            versionCode < latestVersion.code -> RecommendUpdate(
+                latestVersionCode = latestVersion.code,
+                osType = osType,
+            )
+
+            else -> NoUpdate
+        }
+    }
+}

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionService.kt
@@ -16,7 +16,7 @@ class ClientVersionService(
 ) {
     fun checkVersion(osType: OsType, versionCode: Int): VersionPolicyVo {
 
-        val (latestVersion, minimumVersion) = clientVersionCacheService.getActiveVersions(osType)
+        val (latestVersion, recommendedVersion, minimumVersion) = clientVersionCacheService.getActiveVersions(osType)
         if (latestVersion == null || minimumVersion == null) {
             logger.warn { "Failed to find valid client version(Latest or Minimum) for osType: ${osType}" }
             return NoUpdate
@@ -28,7 +28,7 @@ class ClientVersionService(
                 osType = osType
             )
 
-            versionCode < latestVersion.code -> RecommendUpdate(
+            recommendedVersion != null && versionCode < recommendedVersion.code -> RecommendUpdate(
                 latestVersionCode = latestVersion.code,
                 osType = osType,
             )

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/vo/ClientVersionVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/vo/ClientVersionVo.kt
@@ -1,0 +1,35 @@
+package com.whatever.caramel.domain.clientversion.vo
+
+import com.whatever.caramel.domain.clientversion.model.ClientVersion
+import com.whatever.caramel.domain.clientversion.model.OsType
+
+data class SupportedVersionsVo(
+    val latest: ClientVersionVo?,
+    val minimum: ClientVersionVo?,
+)
+
+data class ClientVersionVo(
+    val osType: OsType,
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val build: Int,
+    val code: Int,
+    val isMinimum: Boolean,
+    val releaseNote: String?,
+){
+    companion object {
+        fun from(clientVersion: ClientVersion): ClientVersionVo {
+            return ClientVersionVo(
+                osType = clientVersion.osType,
+                major = clientVersion.major,
+                minor = clientVersion.minor,
+                patch = clientVersion.patch,
+                build = clientVersion.build,
+                code = clientVersion.code,
+                isMinimum = clientVersion.isMinimum,
+                releaseNote = clientVersion.releaseNote
+            )
+        }
+    }
+}

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/vo/ClientVersionVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/vo/ClientVersionVo.kt
@@ -5,6 +5,7 @@ import com.whatever.caramel.domain.clientversion.model.OsType
 
 data class SupportedVersionsVo(
     val latest: ClientVersionVo?,
+    val recommended: ClientVersionVo?,
     val minimum: ClientVersionVo?,
 )
 
@@ -15,7 +16,6 @@ data class ClientVersionVo(
     val patch: Int,
     val build: Int,
     val code: Int,
-    val isMinimum: Boolean,
     val releaseNote: String?,
 ){
     companion object {
@@ -27,8 +27,7 @@ data class ClientVersionVo(
                 patch = clientVersion.patch,
                 build = clientVersion.build,
                 code = clientVersion.code,
-                isMinimum = clientVersion.isMinimum,
-                releaseNote = clientVersion.releaseNote
+                releaseNote = clientVersion.releaseNote,
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/vo/VersionPolicyVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/clientversion/vo/VersionPolicyVo.kt
@@ -1,0 +1,9 @@
+package com.whatever.caramel.domain.clientversion.vo
+
+import com.whatever.caramel.domain.clientversion.model.OsType
+
+sealed interface VersionPolicyVo
+
+data object NoUpdate : VersionPolicyVo
+data class ForceUpdate(val latestVersionCode: Int, val osType: OsType) : VersionPolicyVo
+data class RecommendUpdate(val latestVersionCode: Int, val osType: OsType) : VersionPolicyVo

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
@@ -5,6 +5,8 @@ import com.whatever.caramel.common.global.exception.GlobalExceptionCode
 import com.whatever.caramel.common.global.jwt.JwtHelper
 import com.whatever.caramel.common.global.jwt.JwtHelper.Companion.BEARER_TYPE
 import com.whatever.caramel.common.util.DateTimeUtil
+import com.whatever.caramel.config.CacheType
+import com.whatever.caramel.config.CacheType.OIDC_PUBLIC_KEY
 import com.whatever.caramel.domain.CaramelDomainSpringBootTest
 import com.whatever.caramel.domain.auth.exception.AuthException
 import com.whatever.caramel.domain.auth.exception.AuthExceptionCode.ILLEGAL_KID
@@ -191,7 +193,6 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun signUpOrSignIn_whenUnexpectedException_thenThrowException() {
         // given
-        val oidcPublicKeyCacheName = "oidc-public-key"
         val idToken = "idTokenWithPublicKeyIssue"
         val deviceId = "test-device"
         val user = userRepository.save(
@@ -206,7 +207,7 @@ class AuthServiceTest @Autowired constructor(
             .thenReturn(OIDCPublicKeysResponse())
         whenever(oidcHelper.parseKakaoIdToken(any(), any()))
             .thenThrow(RuntimeException("Unexpected Exception"))
-        whenever(oidcCacheManager.getCache(oidcPublicKeyCacheName))
+        whenever(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName))
             .thenReturn(mock(Cache::class.java))
 
         // when, then
@@ -217,14 +218,13 @@ class AuthServiceTest @Autowired constructor(
                 deviceId = deviceId,
             )
         }
-        verify(oidcCacheManager.getCache(oidcPublicKeyCacheName), never())!!.evictIfPresent(any())
+        verify(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName), never())!!.evictIfPresent(any())
     }
 
     @DisplayName("캐시에 일치하는 oidc 공개키가 없다면 다시 로드 후 정상 흐름으로 동작한다.")
     @Test
     fun signUpOrSignIn() {
         // given
-        val oidcPublicKeyCacheName = "oidc-public-key"
         val idToken = "idTokenWithPublicKeyIssue"
         val deviceId = "test-device"
         val user = userRepository.save(
@@ -257,7 +257,7 @@ class AuthServiceTest @Autowired constructor(
             .whenever(jwtHelper).createAccessToken(user.id)
         doReturn(fakeServiceToken.refreshToken)
             .whenever(jwtHelper).createRefreshToken()
-        whenever(oidcCacheManager.getCache(oidcPublicKeyCacheName))
+        whenever(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName))
             .thenReturn(mock(Cache::class.java))
 
         // when
@@ -268,7 +268,7 @@ class AuthServiceTest @Autowired constructor(
         )
 
         // then
-        verify(oidcCacheManager.getCache(oidcPublicKeyCacheName), never())!!.evictIfPresent(user.platform.name)
+        verify(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName), never())!!.evictIfPresent(user.platform.name)
         assertThat(result.nickname).isEqualTo(user.nickname)
         assertThat(result.accessToken).isEqualTo(fakeServiceToken.accessToken)
         assertThat(result.refreshToken).isEqualTo(fakeServiceToken.refreshToken)
@@ -278,7 +278,6 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun signUpOrSignIn_WithExpiredOidcPublicKey() {
         // given
-        val oidcPublicKeyCacheName = "oidc-public-key"
         val idToken = "idTokenWithPublicKeyIssue"
         val deviceId = "test-device"
         val exception = OidcPublicKeyMismatchException(ILLEGAL_KID)
@@ -314,7 +313,7 @@ class AuthServiceTest @Autowired constructor(
             .whenever(jwtHelper).createAccessToken(user.id)
         doReturn(fakeServiceToken.refreshToken)
             .whenever(jwtHelper).createRefreshToken()
-        whenever(oidcCacheManager.getCache(oidcPublicKeyCacheName))
+        whenever(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName))
             .thenReturn(mock(Cache::class.java))
 
         // when
@@ -325,7 +324,7 @@ class AuthServiceTest @Autowired constructor(
         )
 
         // then
-        verify(oidcCacheManager.getCache(oidcPublicKeyCacheName), times(1))!!.evictIfPresent(user.platform.name)
+        verify(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName), times(1))!!.evictIfPresent(user.platform.name)
         assertThat(result.nickname).isEqualTo(user.nickname)
         assertThat(result.accessToken).isEqualTo(fakeServiceToken.accessToken)
         assertThat(result.refreshToken).isEqualTo(fakeServiceToken.refreshToken)
@@ -335,7 +334,6 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun signUpOrSignIn_whenOIDCPublicKeyNotExists_thenPassEvict() {
         // given
-        val oidcPublicKeyCacheName = "oidc-public-key"
         val idToken = "idTokenWithPublicKeyIssue"
         val deviceId = "test-device"
         val exception = OidcPublicKeyMismatchException(ILLEGAL_KID)
@@ -371,7 +369,7 @@ class AuthServiceTest @Autowired constructor(
             .whenever(jwtHelper).createAccessToken(user.id)
         doReturn(fakeServiceToken.refreshToken)
             .whenever(jwtHelper).createRefreshToken()
-        whenever(oidcCacheManager.getCache(oidcPublicKeyCacheName))
+        whenever(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName))
             .thenReturn(null)
 
         // when
@@ -391,7 +389,6 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun signUpOrSignIn_whenInvalidOidcPublicKey_thenThrowException() {
         // given
-        val oidcPublicKeyCacheName = "oidc-public-key"
         val idToken = "idTokenWithPublicKeyIssue"
         val deviceId = "test-device"
         val exception = OidcPublicKeyMismatchException(ILLEGAL_KID)
@@ -418,7 +415,7 @@ class AuthServiceTest @Autowired constructor(
             .whenever(jwtHelper).createAccessToken(user.id)
         doReturn(fakeServiceToken.refreshToken)
             .whenever(jwtHelper).createRefreshToken()
-        whenever(oidcCacheManager.getCache(oidcPublicKeyCacheName))
+        whenever(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName))
             .thenReturn(mock(Cache::class.java))
 
         // when
@@ -432,7 +429,7 @@ class AuthServiceTest @Autowired constructor(
 
         // then
         assertThat(result.errorCode).isEqualTo(ILLEGAL_KID)
-        verify(oidcCacheManager.getCache(oidcPublicKeyCacheName), times(1))!!.evictIfPresent(user.platform.name)
+        verify(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName), times(1))!!.evictIfPresent(user.platform.name)
     }
 
     @DisplayName("회원 탈퇴 시 유저 상태가 COUPLED라면 커플탈퇴와 유저삭제, 로그아웃을 진행한다.")

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceTest.kt
@@ -1,0 +1,65 @@
+package com.whatever.caramel.domain.clientversion.service
+
+import com.whatever.caramel.domain.CaramelDomainSpringBootTest
+import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.repository.ClientVersionRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import kotlin.test.Test
+
+@CaramelDomainSpringBootTest
+class ClientVersionCacheServiceTest @Autowired constructor(
+    private val redisConnectionFactory: RedisConnectionFactory,
+    private val clientVersionCacheService: ClientVersionCacheService,
+) : ClientVersionServiceTestSupport {
+
+    @MockitoBean
+    private lateinit var clientVersionRepository: ClientVersionRepository
+
+    @AfterEach
+    fun tearDown() {
+        redisConnectionFactory.connection.serverCommands().flushAll()
+    }
+
+    @DisplayName("한번 호출한 뒤에는 캐싱이 적용되어 DB를 조회하지 않는다.")
+    @Test
+    fun getActiveVersions_WithCache() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVersion = createDummyVersion(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val minimumVersion = createDummyVersion(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 9,
+        )
+        whenever(clientVersionRepository.findLatestVersionByOsType(osType)).thenReturn(latestVersion)
+        whenever(clientVersionRepository.findMinimumVersionByOsType(osType)).thenReturn(minimumVersion)
+
+        // when
+        val firstResult = clientVersionCacheService.getActiveVersions(osType)
+        val secondResult = clientVersionCacheService.getActiveVersions(osType)
+
+        // then
+        assertThat(firstResult).isEqualTo(secondResult)
+        assertThat(secondResult.latest?.code).isEqualTo(latestVersion.code)
+        assertThat(secondResult.minimum?.code).isEqualTo(minimumVersion.code)
+
+        verify(clientVersionRepository, times(1)).findLatestVersionByOsType(osType)
+        verify(clientVersionRepository, times(1)).findMinimumVersionByOsType(osType)
+    }
+}

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceTest.kt
@@ -1,7 +1,9 @@
 package com.whatever.caramel.domain.clientversion.service
 
 import com.whatever.caramel.domain.CaramelDomainSpringBootTest
+import com.whatever.caramel.domain.clientversion.model.OsVersionPolicy
 import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.repository.OsVersionPolicyRepository
 import com.whatever.caramel.domain.clientversion.repository.ClientVersionRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -12,6 +14,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.Optional
 import kotlin.test.Test
 
 @CaramelDomainSpringBootTest
@@ -23,6 +26,9 @@ class ClientVersionCacheServiceTest @Autowired constructor(
     @MockitoBean
     private lateinit var clientVersionRepository: ClientVersionRepository
 
+    @MockitoBean
+    private lateinit var osVersionPolicyRepository: OsVersionPolicyRepository
+
     @AfterEach
     fun tearDown() {
         redisConnectionFactory.connection.serverCommands().flushAll()
@@ -33,22 +39,19 @@ class ClientVersionCacheServiceTest @Autowired constructor(
     fun getActiveVersions_WithCache() {
         // given
         val osType = OsType.ANDROID
-        val latestVersion = createDummyVersion(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
+        val latestVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 10)
+        val minimumVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 9)
+        val recommendedVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 9)
+        val policy = OsVersionPolicy(
+            osType = osType,
+            minimumVersion = minimumVersion,
+            recommendedVersion = recommendedVersion
         )
-        val minimumVersion = createDummyVersion(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 9,
-        )
+
         whenever(clientVersionRepository.findLatestVersionByOsType(osType)).thenReturn(latestVersion)
-        whenever(clientVersionRepository.findMinimumVersionByOsType(osType)).thenReturn(minimumVersion)
+
+        // findByIdOrNul은 Kotlin 확장함수이므로, CrudRepository의 findById를 Stubbing
+        whenever(osVersionPolicyRepository.findById(osType)).thenReturn(Optional.of(policy))
 
         // when
         val firstResult = clientVersionCacheService.getActiveVersions(osType)
@@ -58,8 +61,9 @@ class ClientVersionCacheServiceTest @Autowired constructor(
         assertThat(firstResult).isEqualTo(secondResult)
         assertThat(secondResult.latest?.code).isEqualTo(latestVersion.code)
         assertThat(secondResult.minimum?.code).isEqualTo(minimumVersion.code)
+        assertThat(secondResult.recommended?.code).isEqualTo(recommendedVersion.code)
 
         verify(clientVersionRepository, times(1)).findLatestVersionByOsType(osType)
-        verify(clientVersionRepository, times(1)).findMinimumVersionByOsType(osType)
+        verify(osVersionPolicyRepository, times(1)).findById(osType)
     }
 }

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceUnitTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceUnitTest.kt
@@ -1,40 +1,37 @@
 package com.whatever.caramel.domain.clientversion.service
 
 import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.model.OsVersionPolicy
 import com.whatever.caramel.domain.clientversion.repository.ClientVersionRepository
+import com.whatever.caramel.domain.clientversion.repository.OsVersionPolicyRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
+import java.util.Optional
 import kotlin.test.Test
 
 class ClientVersionCacheServiceUnitTest : ClientVersionServiceTestSupport {
     private val mockClientVersionRepository = mockk<ClientVersionRepository>()
-    private val clientVersionCacheService = ClientVersionCacheService(mockClientVersionRepository)
+    private val mockOsVersionPolicyRepository = mockk<OsVersionPolicyRepository>()
+    private val clientVersionCacheService = ClientVersionCacheService(
+        mockClientVersionRepository,
+        mockOsVersionPolicyRepository,
+    )
 
     @DisplayName("최신 버전과 최소 버전이 모두 존재하면, 각 버전을 올바르게 반환한다")
     @Test
     fun getActiveVersions() {
         // given
         val osType = OsType.ANDROID
-        val latestVersion = createDummyVersion(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
-        val minimumVersion = createDummyVersion(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 9,
-        )
+        val latestVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 10)
+        val minimumVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 9)
+        val recommendedVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 9)
+        val policy = OsVersionPolicy(osType, minimumVersion, recommendedVersion)
 
         every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns latestVersion
-        every { mockClientVersionRepository.findMinimumVersionByOsType(osType) } returns minimumVersion
+        every { mockOsVersionPolicyRepository.findById(osType) } returns Optional.of(policy)
 
         // when
         val result = clientVersionCacheService.getActiveVersions(osType)
@@ -42,43 +39,44 @@ class ClientVersionCacheServiceUnitTest : ClientVersionServiceTestSupport {
         // then
         assertThat(result.latest?.code).isEqualTo(latestVersion.code)
         assertThat(result.minimum?.code).isEqualTo(minimumVersion.code)
+        assertThat(result.recommended?.code).isEqualTo(recommendedVersion.code)
 
         verify(exactly = 1) { mockClientVersionRepository.findLatestVersionByOsType(osType) }
-        verify(exactly = 1) { mockClientVersionRepository.findMinimumVersionByOsType(osType) }
+        verify(exactly = 1) { mockOsVersionPolicyRepository.findById(osType) }
     }
 
-    @DisplayName("최신 버전이 최소 버전을 겸하면, findMinimumVersionByOsType은 호출되지 않는다")
+    @DisplayName("정책은 존재하지만 권장 버전(recommendedVersion)이 null이면, 결과의 recommended도 null을 반환한다")
     @Test
-    fun getActiveVersions_WithLatestAndMinimumClientVersion() {
+    fun getActiveVersions_WhenRecommendedVersionIsNullInPolicy() {
         // given
         val osType = OsType.ANDROID
-        val latestAndMinimumVersion = createDummyVersion(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
+        val latestVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 10)
+        val minimumVersion = createDummyVersion(major = 10, minor = 0, patch = 0, build = 9)
+        val policy = OsVersionPolicy(osType, minimumVersion, null)
 
-        every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns latestAndMinimumVersion
+        every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns latestVersion
+        every { mockOsVersionPolicyRepository.findById(osType) } returns Optional.of(policy)
 
         // when
         val result = clientVersionCacheService.getActiveVersions(osType)
 
         // then
-        assertThat(result.latest?.code).isEqualTo(latestAndMinimumVersion.code)
-        assertThat(result.minimum?.code).isEqualTo(latestAndMinimumVersion.code)
+        assertThat(result.latest?.code).isEqualTo(latestVersion.code)
+        assertThat(result.minimum?.code).isEqualTo(minimumVersion.code)
+        assertThat(result.recommended?.code).isNull()
 
-        verify(exactly = 0) { mockClientVersionRepository.findMinimumVersionByOsType(any()) }
+        verify(exactly = 1) { mockClientVersionRepository.findLatestVersionByOsType(osType) }
+        verify(exactly = 1) { mockOsVersionPolicyRepository.findById(osType) }
     }
 
-    @DisplayName("DB에 버전 정보가 없으면, latest와 minimum 모두 null을 반환한다")
+    @DisplayName("DB에 버전 정보가 없으면, latest와 minimum, recommended 모두 null을 반환한다")
     @Test
     fun getActiveVersions_WhenClientVersionNotExists_ThenReturnNull() {
         // given
         val osType = OsType.ANDROID
+
         every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns null
-        every { mockClientVersionRepository.findMinimumVersionByOsType(osType) } returns null
+        every { mockOsVersionPolicyRepository.findById(osType) } returns Optional.empty()
 
         // when
         val result = clientVersionCacheService.getActiveVersions(osType)
@@ -86,7 +84,25 @@ class ClientVersionCacheServiceUnitTest : ClientVersionServiceTestSupport {
         // then
         assertThat(result.latest).isNull()
         assertThat(result.minimum).isNull()
+        assertThat(result.recommended).isNull()
+    }
 
-        verify(exactly = 0) { mockClientVersionRepository.findMinimumVersionByOsType(any()) }
+    @DisplayName("DB에 정책 정보가 없으면, minimum과 recommended는 null을 반환한다")
+    @Test
+    fun getActiveVersions_WhenPolicyNotExists() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVersion = createDummyVersion(10, 0, 1, 0)
+
+        every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns latestVersion
+        every { mockOsVersionPolicyRepository.findById(osType) } returns Optional.empty()
+
+        // when
+        val result = clientVersionCacheService.getActiveVersions(osType)
+
+        // then
+        assertThat(result.latest).isNotNull()
+        assertThat(result.minimum).isNull()
+        assertThat(result.recommended).isNull()
     }
 }

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceUnitTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionCacheServiceUnitTest.kt
@@ -1,0 +1,92 @@
+package com.whatever.caramel.domain.clientversion.service
+
+import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.repository.ClientVersionRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.Test
+
+class ClientVersionCacheServiceUnitTest : ClientVersionServiceTestSupport {
+    private val mockClientVersionRepository = mockk<ClientVersionRepository>()
+    private val clientVersionCacheService = ClientVersionCacheService(mockClientVersionRepository)
+
+    @DisplayName("최신 버전과 최소 버전이 모두 존재하면, 각 버전을 올바르게 반환한다")
+    @Test
+    fun getActiveVersions() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVersion = createDummyVersion(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val minimumVersion = createDummyVersion(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 9,
+        )
+
+        every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns latestVersion
+        every { mockClientVersionRepository.findMinimumVersionByOsType(osType) } returns minimumVersion
+
+        // when
+        val result = clientVersionCacheService.getActiveVersions(osType)
+
+        // then
+        assertThat(result.latest?.code).isEqualTo(latestVersion.code)
+        assertThat(result.minimum?.code).isEqualTo(minimumVersion.code)
+
+        verify(exactly = 1) { mockClientVersionRepository.findLatestVersionByOsType(osType) }
+        verify(exactly = 1) { mockClientVersionRepository.findMinimumVersionByOsType(osType) }
+    }
+
+    @DisplayName("최신 버전이 최소 버전을 겸하면, findMinimumVersionByOsType은 호출되지 않는다")
+    @Test
+    fun getActiveVersions_WithLatestAndMinimumClientVersion() {
+        // given
+        val osType = OsType.ANDROID
+        val latestAndMinimumVersion = createDummyVersion(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+
+        every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns latestAndMinimumVersion
+
+        // when
+        val result = clientVersionCacheService.getActiveVersions(osType)
+
+        // then
+        assertThat(result.latest?.code).isEqualTo(latestAndMinimumVersion.code)
+        assertThat(result.minimum?.code).isEqualTo(latestAndMinimumVersion.code)
+
+        verify(exactly = 0) { mockClientVersionRepository.findMinimumVersionByOsType(any()) }
+    }
+
+    @DisplayName("DB에 버전 정보가 없으면, latest와 minimum 모두 null을 반환한다")
+    @Test
+    fun getActiveVersions_WhenClientVersionNotExists_ThenReturnNull() {
+        // given
+        val osType = OsType.ANDROID
+        every { mockClientVersionRepository.findLatestVersionByOsType(osType) } returns null
+        every { mockClientVersionRepository.findMinimumVersionByOsType(osType) } returns null
+
+        // when
+        val result = clientVersionCacheService.getActiveVersions(osType)
+
+        // then
+        assertThat(result.latest).isNull()
+        assertThat(result.minimum).isNull()
+
+        verify(exactly = 0) { mockClientVersionRepository.findMinimumVersionByOsType(any()) }
+    }
+}

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceTestSupport.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceTestSupport.kt
@@ -2,8 +2,27 @@ package com.whatever.caramel.domain.clientversion.service
 
 import com.whatever.caramel.domain.clientversion.model.ClientVersion
 import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.vo.ClientVersionVo
 
 interface ClientVersionServiceTestSupport {
+    fun createDummyVersionVo(
+        isMinimum: Boolean,
+        major: Int,
+        minor: Int,
+        patch: Int,
+        build: Int,
+    ): ClientVersionVo {
+        return ClientVersionVo.from(
+            createDummyVersion(
+                isMinimum = isMinimum,
+                major = major,
+                minor = minor,
+                patch = patch,
+                build = build
+            )
+        )
+    }
+
     fun createDummyVersion(
         isMinimum: Boolean,
         major: Int,

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceTestSupport.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceTestSupport.kt
@@ -1,0 +1,24 @@
+package com.whatever.caramel.domain.clientversion.service
+
+import com.whatever.caramel.domain.clientversion.model.ClientVersion
+import com.whatever.caramel.domain.clientversion.model.OsType
+
+interface ClientVersionServiceTestSupport {
+    fun createDummyVersion(
+        isMinimum: Boolean,
+        major: Int,
+        minor: Int,
+        patch: Int,
+        build: Int,
+    ): ClientVersion {
+        return ClientVersion(
+            osType = OsType.ANDROID,
+            isMinimum = isMinimum,
+            major = major,
+            minor = minor,
+            patch = patch,
+            build = build,
+            releaseNote = "test version",
+        )
+    }
+}

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceTestSupport.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceTestSupport.kt
@@ -6,7 +6,6 @@ import com.whatever.caramel.domain.clientversion.vo.ClientVersionVo
 
 interface ClientVersionServiceTestSupport {
     fun createDummyVersionVo(
-        isMinimum: Boolean,
         major: Int,
         minor: Int,
         patch: Int,
@@ -14,7 +13,6 @@ interface ClientVersionServiceTestSupport {
     ): ClientVersionVo {
         return ClientVersionVo.from(
             createDummyVersion(
-                isMinimum = isMinimum,
                 major = major,
                 minor = minor,
                 patch = patch,
@@ -24,7 +22,6 @@ interface ClientVersionServiceTestSupport {
     }
 
     fun createDummyVersion(
-        isMinimum: Boolean,
         major: Int,
         minor: Int,
         patch: Int,
@@ -32,7 +29,6 @@ interface ClientVersionServiceTestSupport {
     ): ClientVersion {
         return ClientVersion(
             osType = OsType.ANDROID,
-            isMinimum = isMinimum,
             major = major,
             minor = minor,
             patch = patch,

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceUnitTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceUnitTest.kt
@@ -1,0 +1,185 @@
+package com.whatever.caramel.domain.clientversion.service
+
+import com.whatever.caramel.domain.clientversion.model.OsType
+import com.whatever.caramel.domain.clientversion.vo.ForceUpdate
+import com.whatever.caramel.domain.clientversion.vo.NoUpdate
+import com.whatever.caramel.domain.clientversion.vo.RecommendUpdate
+import com.whatever.caramel.domain.clientversion.vo.SupportedVersionsVo
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import kotlin.test.Test
+
+class ClientVersionServiceUnitTest : ClientVersionServiceTestSupport {
+    private val mockClientVersionCacheService = mockk<ClientVersionCacheService>()
+    private val clientVersionService = ClientVersionService(mockClientVersionCacheService)
+
+    @DisplayName("사용자 버전이 최소 버전보다 낮으면, ForceUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenLowerThanMinimumVersion_ThenReturnForceUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVo = createDummyVersionVo(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val minimumVo = createDummyVersionVo(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 8,
+        )
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+        val userVersionCode = minimumVo.code - 1  // 최소 지원 버전보다 낮은 버전
+
+        // when
+        val result = clientVersionService.checkVersion(osType, userVersionCode)
+
+        // then
+        assertThat(result).isInstanceOf(ForceUpdate::class.java)
+        assertThat((result as ForceUpdate).latestVersionCode).isEqualTo(latestVo.code)
+    }
+
+    @DisplayName("사용자 버전이 최소 버전보다는 높고 최신 버전보다는 낮으면, RecommendUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenBetweenMinimumAndLatest_ThenReturnRecommendUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVo = createDummyVersionVo(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val minimumVo = createDummyVersionVo(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 8,
+        )
+        val betweenVersionCode = (latestVo.code + minimumVo.code) shr 1  // 최소 지원 버전과 최신 버전의 사이
+
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+
+        // when
+        val result = clientVersionService.checkVersion(osType, betweenVersionCode)
+
+        // then
+        assertThat(result).isInstanceOf(RecommendUpdate::class.java)
+        assertThat((result as RecommendUpdate).latestVersionCode).isEqualTo(latestVo.code)
+    }
+
+    @DisplayName("사용자 버전이 최신 버전과 같으면, NoUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenEqualLatestVersion_ThenReturnNoUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVo = createDummyVersionVo(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val minimumVo = createDummyVersionVo(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 8,
+        )
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+        val userVersionCode = latestVo.code // 최신 버전과 동일
+
+        // when
+        val result = clientVersionService.checkVersion(osType, userVersionCode)
+
+        // then
+        assertThat(result).isEqualTo(NoUpdate)
+    }
+
+    @DisplayName("사용자 버전이 최신 버전보다 높으면, NoUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenHigherThanLatestVersion_ThenReturnNoUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVo = createDummyVersionVo(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val minimumVo = createDummyVersionVo(
+            isMinimum = true,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 8,
+        )
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+        val userVersionCode = latestVo.code + 1 // 최신 버전보다 높은 버전
+
+        // when
+        val result = clientVersionService.checkVersion(osType, userVersionCode)
+
+        // then
+        assertThat(result).isEqualTo(NoUpdate)
+    }
+
+    @DisplayName("최신 버전 정보가 없으면, NoUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenLatestVersionNotExists_ThenReturnNoUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val versionCode = 10000000
+
+        val supportedVersions = SupportedVersionsVo(latest = null, minimum = null)
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+        // when
+        val result = clientVersionService.checkVersion(osType, versionCode)
+
+        // then
+        assertThat(result).isEqualTo(NoUpdate)
+    }
+
+    @DisplayName("최소 지원 버전 정보가 없으면, NoUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenMinimumVersionNotExists_ThenReturnNoUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVo = createDummyVersionVo(
+            isMinimum = false,
+            major = 10,
+            minor = 0,
+            patch = 0,
+            build = 10,
+        )
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = null)
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+        // when
+        val result = clientVersionService.checkVersion(osType, latestVo.code)
+
+        // then
+        assertThat(result).isEqualTo(NoUpdate)
+    }
+}

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceUnitTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/clientversion/service/ClientVersionServiceUnitTest.kt
@@ -15,29 +15,19 @@ class ClientVersionServiceUnitTest : ClientVersionServiceTestSupport {
     private val mockClientVersionCacheService = mockk<ClientVersionCacheService>()
     private val clientVersionService = ClientVersionService(mockClientVersionCacheService)
 
-    @DisplayName("사용자 버전이 최소 버전보다 낮으면, ForceUpdate를 반환한다")
+    @DisplayName("사용자 버전 경계이 최소 버전 경계보다 낮으면, ForceUpdate를 반환한다")
     @Test
     fun checkVersion_WhenLowerThanMinimumVersion_ThenReturnForceUpdate() {
         // given
         val osType = OsType.ANDROID
-        val latestVo = createDummyVersionVo(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
-        val minimumVo = createDummyVersionVo(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 8,
-        )
-        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+        val latestVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 10)
+        val recommendedVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 9)
+        val minimumVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 8)
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, recommended = recommendedVo, minimum = minimumVo)
+
         every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
 
-        val userVersionCode = minimumVo.code - 1  // 최소 지원 버전보다 낮은 버전
+        val userVersionCode = minimumVo.code - 1  // 최소 지원 버전 경계보다 낮은 버전 경계
 
         // when
         val result = clientVersionService.checkVersion(osType, userVersionCode)
@@ -47,63 +37,43 @@ class ClientVersionServiceUnitTest : ClientVersionServiceTestSupport {
         assertThat((result as ForceUpdate).latestVersionCode).isEqualTo(latestVo.code)
     }
 
-    @DisplayName("사용자 버전이 최소 버전보다는 높고 최신 버전보다는 낮으면, RecommendUpdate를 반환한다")
+    @DisplayName("사용자 버전 경계이 최소 버전 경계보다는 높고 권장 버전 경계보다는 낮으면, RecommendUpdate를 반환한다")
     @Test
     fun checkVersion_WhenBetweenMinimumAndLatest_ThenReturnRecommendUpdate() {
         // given
         val osType = OsType.ANDROID
-        val latestVo = createDummyVersionVo(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
-        val minimumVo = createDummyVersionVo(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 8,
-        )
-        val betweenVersionCode = (latestVo.code + minimumVo.code) shr 1  // 최소 지원 버전과 최신 버전의 사이
+        val latestVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 11)
+        val recommendedVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 10)
+        val minimumVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 8)
 
-        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+       val clientVersionCode = (minimumVo.code + recommendedVo.code) shr 1
+
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, recommended = recommendedVo, minimum = minimumVo)
         every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
 
 
         // when
-        val result = clientVersionService.checkVersion(osType, betweenVersionCode)
+        val result = clientVersionService.checkVersion(osType, clientVersionCode)
 
         // then
         assertThat(result).isInstanceOf(RecommendUpdate::class.java)
         assertThat((result as RecommendUpdate).latestVersionCode).isEqualTo(latestVo.code)
     }
 
-    @DisplayName("사용자 버전이 최신 버전과 같으면, NoUpdate를 반환한다")
+    @DisplayName("사용자 버전 경계이 최신 버전 경계과 같으면, NoUpdate를 반환한다")
     @Test
     fun checkVersion_WhenEqualLatestVersion_ThenReturnNoUpdate() {
         // given
         val osType = OsType.ANDROID
-        val latestVo = createDummyVersionVo(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
-        val minimumVo = createDummyVersionVo(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 8,
-        )
-        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+        val latestVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 10)
+        val recommendedVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 9)
+        val minimumVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 8)
+
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, recommended = recommendedVo, minimum = minimumVo)
 
         every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
 
-        val userVersionCode = latestVo.code // 최신 버전과 동일
+        val userVersionCode = latestVo.code // 최신 버전 경계과 동일
 
         // when
         val result = clientVersionService.checkVersion(osType, userVersionCode)
@@ -112,30 +82,19 @@ class ClientVersionServiceUnitTest : ClientVersionServiceTestSupport {
         assertThat(result).isEqualTo(NoUpdate)
     }
 
-    @DisplayName("사용자 버전이 최신 버전보다 높으면, NoUpdate를 반환한다")
+    @DisplayName("사용자 버전 경계이 최신 버전 경계보다 높으면, NoUpdate를 반환한다")
     @Test
     fun checkVersion_WhenHigherThanLatestVersion_ThenReturnNoUpdate() {
         // given
         val osType = OsType.ANDROID
-        val latestVo = createDummyVersionVo(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
-        val minimumVo = createDummyVersionVo(
-            isMinimum = true,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 8,
-        )
-        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = minimumVo)
+        val latestVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 10)
+        val recommendedVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 9)
+        val minimumVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 8)
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, recommended = recommendedVo, minimum = minimumVo)
 
         every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
 
-        val userVersionCode = latestVo.code + 1 // 최신 버전보다 높은 버전
+        val userVersionCode = latestVo.code + 1 // 최신 버전 경계보다 높은 버전 경계
 
         // when
         val result = clientVersionService.checkVersion(osType, userVersionCode)
@@ -144,14 +103,14 @@ class ClientVersionServiceUnitTest : ClientVersionServiceTestSupport {
         assertThat(result).isEqualTo(NoUpdate)
     }
 
-    @DisplayName("최신 버전 정보가 없으면, NoUpdate를 반환한다")
+    @DisplayName("최신 버전 경계 정보가 없으면, NoUpdate를 반환한다")
     @Test
     fun checkVersion_WhenLatestVersionNotExists_ThenReturnNoUpdate() {
         // given
         val osType = OsType.ANDROID
         val versionCode = 10000000
 
-        val supportedVersions = SupportedVersionsVo(latest = null, minimum = null)
+        val supportedVersions = SupportedVersionsVo(latest = null, recommended = null, minimum = null)
         every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
 
         // when
@@ -161,23 +120,37 @@ class ClientVersionServiceUnitTest : ClientVersionServiceTestSupport {
         assertThat(result).isEqualTo(NoUpdate)
     }
 
-    @DisplayName("최소 지원 버전 정보가 없으면, NoUpdate를 반환한다")
+    @DisplayName("최소 지원 버전 경계 정보가 없으면, NoUpdate를 반환한다")
     @Test
     fun checkVersion_WhenMinimumVersionNotExists_ThenReturnNoUpdate() {
         // given
         val osType = OsType.ANDROID
-        val latestVo = createDummyVersionVo(
-            isMinimum = false,
-            major = 10,
-            minor = 0,
-            patch = 0,
-            build = 10,
-        )
-        val supportedVersions = SupportedVersionsVo(latest = latestVo, minimum = null)
+        val latestVo = createDummyVersionVo(major = 10, minor = 0, patch = 0, build = 10)
+        val supportedVersions = SupportedVersionsVo(latest = latestVo, recommended = null, minimum = null)
         every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
 
         // when
         val result = clientVersionService.checkVersion(osType, latestVo.code)
+
+        // then
+        assertThat(result).isEqualTo(NoUpdate)
+    }
+
+    @DisplayName("권장 버전이 설정되지 않았고 사용자 버전이 최소 버전 이상이면, NoUpdate를 반환한다")
+    @Test
+    fun checkVersion_WhenRecommendedIsNull_ThenReturnNoUpdate() {
+        // given
+        val osType = OsType.ANDROID
+        val latestVo = createDummyVersionVo(10, 0, 0, 10)
+        val minimumVo = createDummyVersionVo(10, 0, 0, 8)
+
+        val supportedVersions = SupportedVersionsVo(latest = latestVo,  recommended = null, minimum = minimumVo)
+        every { mockClientVersionCacheService.getActiveVersions(osType) } returns supportedVersions
+
+        val userVersionCode = minimumVo.code + 1
+
+        // when
+        val result = clientVersionService.checkVersion(osType, userVersionCode)
 
         // then
         assertThat(result).isEqualTo(NoUpdate)

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/AppleFeignClient.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/AppleFeignClient.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping
 interface AppleOIDCClient {
 
     @Cacheable(
-        cacheNames = ["oidc-public-key"],
+        cacheNames = ["auth:oidc-public-key"],
         key = "'APPLE'",
     )
     @GetMapping(

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/AppleFeignClient.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/AppleFeignClient.kt
@@ -18,7 +18,6 @@ interface AppleOIDCClient {
     @Cacheable(
         cacheNames = ["oidc-public-key"],
         key = "'APPLE'",
-        cacheManager = "oidcCacheManager"
     )
     @GetMapping(
         path = ["/auth/keys"],

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/KakaoFeignClient.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/KakaoFeignClient.kt
@@ -54,7 +54,6 @@ interface KakaoOIDCClient {
     @Cacheable(
         cacheNames = ["oidc-public-key"],
         key = "'KAKAO'",
-        cacheManager = "oidcCacheManager"
     )
     @GetMapping(
         path = ["/.well-known/jwks.json"],

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/KakaoFeignClient.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/client/KakaoFeignClient.kt
@@ -52,7 +52,7 @@ interface KakaoKapiClient {
 interface KakaoOIDCClient {
 
     @Cacheable(
-        cacheNames = ["oidc-public-key"],
+        cacheNames = ["auth:oidc-public-key"],
         key = "'KAKAO'",
     )
     @GetMapping(


### PR DESCRIPTION
## 관련 이슈
- close #259

## 작업한 내용
- CacheConfig의 cache manager를 하나로 통일
  - Redis만 사용하기 때문에 설정 단순화 및 관리 포인트를 줄이고자 했습니다.
- application.yaml에 store uri 정보 추가
  - 하드코딩 대신에 별도로 분리했습니다.
- client version 기록을 위한 entity, repository 추가
- 버전 체크 api & service 추가

## PR 포인트
- `GenericJackson2JsonRedisSerializer()` 내부에서 `JacksonObjectReader.create()`를 호출해 KotlinModule이 추가되지 않은 objectMapper가 사용되고 있었습니다. 
`@JsonProperty`로 프로퍼티명을 명시해주면 data class도 역직렬화가 가능하지만, 추후 편의를 위해 직접 KotlinModule을 추가한 objectMapper를 주입해주었습니다.