### PR TITLE
[Fix] CaramelScheduleException 객체 생성 시 누락된 errorUi 추가

### DIFF
--- a/.github/workflows/caramel-ci-test.yml
+++ b/.github/workflows/caramel-ci-test.yml
@@ -61,7 +61,7 @@ jobs:
         ports:
           - '6379:6379'
       postgresql:
-        image: docker.io/bitnami/postgresql:17
+        image: docker.io/bitnamilegacy/postgresql:17
         ports:
           - '5432:5432'
         env:

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/exception/ScheduleException.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/calendarevent/exception/ScheduleException.kt
@@ -11,19 +11,19 @@ open class CaramelScheduleException(
 class ScheduleNotFoundException(
     errorCode: ScheduleExceptionCode,
     errorUi: ErrorUi = ErrorUi.Toast("일정 정보를 찾을 수 없어요."),
-) : CaramelScheduleException(errorCode)
+) : CaramelScheduleException(errorCode, errorUi)
 
 class ScheduleIllegalArgumentException(
     errorCode: ScheduleExceptionCode,
     errorUi: ErrorUi,
-) : CaramelScheduleException(errorCode)
+) : CaramelScheduleException(errorCode, errorUi)
 
 class ScheduleIllegalStateException(
     errorCode: ScheduleExceptionCode,
     errorUi: ErrorUi,
-) : CaramelScheduleException(errorCode)
+) : CaramelScheduleException(errorCode, errorUi)
 
 class ScheduleAccessDeniedException(
     errorCode: ScheduleExceptionCode,
     errorUi: ErrorUi = ErrorUi.Toast("커플 멤버가 작성한 일정만 접근할 수 있어요."),
-) : CaramelScheduleException(errorCode)
+) : CaramelScheduleException(errorCode, errorUi)


### PR DESCRIPTION
## 관련 이슈
- close #268 

## 작업한 내용
- 예외 객체 생성 시 누락된 errorUi 인자 추가
