### PR TITLE
[Refactor] 배치 쿼리 수정

### DIFF
--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/ScheduleNotificationAddBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/ScheduleNotificationAddBatchConfig.kt
@@ -45,7 +45,7 @@ class ScheduleNotificationAddBatchConfig(
         val query = if (leapYearPredicate) {
             """
                 SELECT DISTINCT u FROM User u
-                JOIN FETCH u._couple c
+                JOIN u._couple c
                 WHERE (function('TO_CHAR', u.birthDate, 'MM') = '02' AND function('TO_CHAR', u.birthDate, 'DD') = '28')
                    OR (function('TO_CHAR', u.birthDate, 'MM') = '02' AND function('TO_CHAR', u.birthDate, 'DD') = '29')
                 ORDER BY u.id
@@ -53,7 +53,7 @@ class ScheduleNotificationAddBatchConfig(
         } else {
             """
                 SELECT DISTINCT u FROM User u
-                JOIN FETCH u._couple c
+                JOIN u._couple c
                 WHERE function('TO_CHAR', u.birthDate, 'MM') = LPAD(CAST(:month AS text), 2, '0')
                 AND function('TO_CHAR', u.birthDate, 'DD') = LPAD(CAST(:day AS text), 2, '0')
                 ORDER BY u.id

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/ScheduleNotificationAddBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/ScheduleNotificationAddBatchConfig.kt
@@ -47,15 +47,15 @@ class ScheduleNotificationAddBatchConfig(
                 SELECT DISTINCT u FROM User u
                 JOIN u._couple c
                 WHERE (function('TO_CHAR', u.birthDate, 'MM') = '02' AND function('TO_CHAR', u.birthDate, 'DD') = '28')
-                   OR (function('TO_CHAR', u.birthDate, 'MM') = '02' AND function('TO_CHAR', u.birthDate, 'DD') = '29')
+                OR (function('TO_CHAR', u.birthDate, 'MM') = '02' AND function('TO_CHAR', u.birthDate, 'DD') = '29')
                 ORDER BY u.id
             """.trimIndent()
         } else {
             """
                 SELECT DISTINCT u FROM User u
                 JOIN u._couple c
-                WHERE function('TO_CHAR', u.birthDate, 'MM') = LPAD(CAST(:month AS text), 2, '0')
-                AND function('TO_CHAR', u.birthDate, 'DD') = LPAD(CAST(:day AS text), 2, '0')
+                WHERE function('TO_CHAR', u.birthDate, 'MM') = :month
+                AND function('TO_CHAR', u.birthDate, 'DD') = :day
                 ORDER BY u.id
             """.trimIndent()
         }
@@ -67,7 +67,7 @@ class ScheduleNotificationAddBatchConfig(
             setQueryString(query)
             if (leapYearPredicate.not()) {
                 setParameterValues(
-                    mapOf("month" to month, "day" to day)
+                    mapOf("month" to String.format("%02d", month), "day" to String.format("%02d", day))
                 )
             }
             pageSize = DEFAULT_BATCH_SIZE


### PR DESCRIPTION
## 관련 이슈

19일에 read_count 가 0인걸 보니, 쿼리를 통해 가져온, 즉 매칭된 데이터가 없다고 나온건데요,
쿼리를 수정해봤어요! 다시 테스트해볼게요~~

<img width="1141" height="236" alt="image" src="https://github.com/user-attachments/assets/0f0af5c2-76e2-4f45-9a4a-bd19937da97a" />

성공한 경우는 아래처럼 read_count 가 1, write_count 가 1로 나오고 (쓰고 읽은 데이터가 1개인 경우)
<img width="1008" height="63" alt="image" src="https://github.com/user-attachments/assets/7fff3cfc-e2e4-48a9-b36b-d220b555098c" />

아래처럼 잘 들어가야해요
<img width="1425" height="61" alt="image" src="https://github.com/user-attachments/assets/a167309b-cdc6-4fac-bd2f-f06d6d149fff" />


## 작업한 내용
- 쿼리수정
- couple을 fetch join 했지만, 로직이나 쿼리상 커플의 값을 사용하진 않아 영속화 할 필요가 없다고 생각해서 fetch는 뻈어용 
- 월, 일을 %02d 를 통해 자릿수를 맞춰줬어요

## PR 포인트
- 