### PR TITLE
[Refactor] user id 응답이 포햠된 로그인 V2 & 토큰 재발행 V2 api 추가

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/controller/AuthController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/controller/AuthController.kt
@@ -3,6 +3,7 @@ package com.whatever.caramel.api.auth.controller
 import com.whatever.caramel.api.auth.dto.ServiceTokenResponse
 import com.whatever.caramel.api.auth.dto.SignInRequest
 import com.whatever.caramel.api.auth.dto.SignInResponse
+import com.whatever.caramel.api.auth.dto.SignInResponseV2
 import com.whatever.caramel.common.global.annotation.DisableSwaggerAuthButton
 import com.whatever.caramel.common.global.constants.CaramelHttpHeaders.AUTH_JWT_HEADER
 import com.whatever.caramel.common.global.constants.CaramelHttpHeaders.DEVICE_ID
@@ -18,7 +19,6 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.RestController
     description = "로그인, 토큰 갱신 등 인증과 관련된 API"
 )
 @RestController
-@RequestMapping("/v1/auth")
 class AuthController(
     private val authService: AuthService,
 ) {
@@ -44,7 +43,7 @@ class AuthController(
             ApiResponse(responseCode = "403", description = "유효하지 않은 토큰"),
         ]
     )
-    @PostMapping("/sign-in")
+    @PostMapping("/v1/auth/sign-in")
     fun signIn(
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
         @RequestBody request: SignInRequest,
@@ -57,6 +56,34 @@ class AuthController(
         return SignInResponse.from(signInVo).succeed()
     }
 
+    @DisableSwaggerAuthButton
+    @Operation(
+        summary = "로그인 or 회원가입 v2",
+        description = """
+            ### 이미 회원인 경우 로그인을, 그렇지 않다면 회원가입을 진행합니다.
+            
+            - 회원가입을 진행한 유저는 NEW 상태로 생성되며, 프로필 생성을 진행해야 합니다.
+            - 반환값에 user id가 추가된 api입니다.
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "로그인 성공"),
+            ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            ApiResponse(responseCode = "403", description = "유효하지 않은 토큰"),
+        ]
+    )
+    @PostMapping("/v2/auth/sign-in")
+    fun signInV2(
+        @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
+        @RequestBody request: SignInRequest,
+    ): CaramelApiResponse<SignInResponseV2> {
+        val signInVo = authService.signUpOrSignIn(
+            loginPlatform = request.loginPlatform,
+            idToken = request.idToken,
+            deviceId = deviceId
+        )
+        return SignInResponseV2.from(signInVo).succeed()
+    }
+
     @Operation(
         summary = "로그아웃",
         description = """
@@ -67,7 +94,7 @@ class AuthController(
             - 파기된 토큰은 재사용이 불가능하고, 새롭게 로그인을 하여 발급받아야 합니다.
         """,
     )
-    @PostMapping("/sign-out")
+    @PostMapping("/v1/auth/sign-out")
     fun signOut(
         @Parameter(hidden = true) @RequestHeader(name = AUTH_JWT_HEADER, required = true) bearerAccessToken: String,
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
@@ -95,7 +122,7 @@ class AuthController(
             ApiResponse(responseCode = "403", description = "리프레시 토큰 만료. 재로그인 필요."),
         ]
     )
-    @PostMapping("/refresh")
+    @PostMapping("/v1/auth/refresh")
     fun refresh(
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
         @RequestBody request: ServiceTokenResponse,
@@ -120,7 +147,7 @@ class AuthController(
             - 로그아웃을 진행합니다.
         """,
     )
-    @DeleteMapping("/account")
+    @DeleteMapping("/v1/auth/account")
     fun deleteUser(
         @Parameter(hidden = true) @RequestHeader(name = AUTH_JWT_HEADER, required = true) bearerAccessToken: String,
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/controller/AuthController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/controller/AuthController.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.api.auth.controller
 
 import com.whatever.caramel.api.auth.dto.ServiceTokenResponse
+import com.whatever.caramel.api.auth.dto.TokenRefreshResponse
 import com.whatever.caramel.api.auth.dto.SignInRequest
 import com.whatever.caramel.api.auth.dto.SignInResponse
 import com.whatever.caramel.api.auth.dto.SignInResponseV2
@@ -133,6 +134,36 @@ class AuthController(
             deviceId = deviceId,
         )
         return ServiceTokenResponse.from(serviceTokenVo).succeed()
+    }
+
+    @DisableSwaggerAuthButton
+    @Operation(
+        summary = "토큰 refresh v2",
+        description = """
+            ### 새로운 Access Token, Refresh Token을 재발급합니다.
+            
+            - 전송한 Access Token과 Refresh Token이 서버 측에서 파기됩니다.
+            
+            - 해당 요청 이후에는 새롭게 발급된 토큰을 사용해야 합니다.
+            
+            - 반환값에 user id가 추가된 api입니다.
+        """,
+        responses = [
+            ApiResponse(responseCode = "200", description = "발급 완료"),
+            ApiResponse(responseCode = "403", description = "리프레시 토큰 만료. 재로그인 필요."),
+        ]
+    )
+    @PostMapping("/v2/auth/refresh")
+    fun refreshV2(
+        @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
+        @RequestBody request: ServiceTokenResponse,
+    ): CaramelApiResponse<TokenRefreshResponse> {
+        val serviceTokenVo = authService.refresh(
+            accessToken = request.accessToken,
+            refreshToken = request.refreshToken,
+            deviceId = deviceId,
+        )
+        return TokenRefreshResponse.from(serviceTokenVo).succeed()
     }
 
     @Operation(

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/dto/ServiceTokenResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/dto/ServiceTokenResponse.kt
@@ -19,3 +19,23 @@ data class ServiceTokenResponse(
         }
     }
 }
+
+@Schema(description = "JWT 갱신 응답 DTO")
+data class TokenRefreshResponse(
+    @Schema(description = "서버에서 발급한 JWT(access, refresh) 정보")
+    val serviceToken: ServiceTokenResponse,
+    @Schema(description = "토큰 refresh 유저의 고유 ID")
+    val userId: Long,
+) {
+    companion object {
+        fun from(serviceTokenVo: ServiceTokenVo): TokenRefreshResponse {
+            return TokenRefreshResponse(
+                serviceToken = ServiceTokenResponse(
+                    accessToken = serviceTokenVo.accessToken,
+                    refreshToken = serviceTokenVo.refreshToken
+                ),
+                userId = serviceTokenVo.userId,
+            )
+        }
+    }
+}

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/dto/SignInResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/dto/SignInResponse.kt
@@ -37,3 +37,40 @@ data class SignInResponse(
         }
     }
 }
+
+@Schema(description = "로그인 성공 응답 DTO V2")
+data class SignInResponseV2(
+    @Schema(description = "서버에서 발급한 JWT(access, refresh) 정보")
+    val serviceToken: ServiceTokenResponse,
+
+    @Schema(description = "로그인한 유저의 고유 ID")
+    val userId: Long,
+
+    @Schema(description = "유저의 현재 상태")
+    val userStatus: UserStatus,
+
+    @Schema(description = "유저의 닉네임. null일 수 있음.", nullable = true)
+    val nickname: String?,
+
+    @Schema(description = "유저의 생일. null일 수 있음.", nullable = true)
+    val birthDay: LocalDate?,
+
+    @Schema(description = "유저가 속한 커플 id. null일 수 있음.", nullable = true)
+    val coupleId: Long?,
+) {
+    companion object {
+        fun from(signInVo: SignInVo): SignInResponseV2 {
+            return SignInResponseV2(
+                serviceToken = ServiceTokenResponse(
+                    accessToken = signInVo.accessToken,
+                    refreshToken = signInVo.refreshToken
+                ),
+                userId = signInVo.userId,
+                userStatus = UserStatus.valueOf(signInVo.userStatus),
+                nickname = signInVo.nickname,
+                birthDay = signInVo.birthDay,
+                coupleId = signInVo.coupleId,
+            )
+        }
+    }
+}

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/config/SecurityConfig.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/config/SecurityConfig.kt
@@ -93,6 +93,8 @@ class SecurityConfig(
                 // 1. Public Access
                 authorize(HttpMethod.POST, "/v1/auth/sign-in", permitAll)
                 authorize(HttpMethod.POST, "/v1/auth/refresh", permitAll)
+                authorize(HttpMethod.POST, "/v2/auth/sign-in", permitAll)
+                authorize(HttpMethod.POST, "/v2/auth/refresh", permitAll)
                 authorize("/sample/**", permitAll)
                 authorize("${actuatorPath}/**", permitAll)
                 authorize("/v1/client-versions/**", permitAll)

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
@@ -161,6 +161,7 @@ class AuthService(
         return ServiceTokenVo.from(
             accessToken,
             refreshToken,
+            userId,
         )
     }
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/ServiceTokenVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/ServiceTokenVo.kt
@@ -3,12 +3,14 @@ package com.whatever.caramel.domain.auth.vo
 data class ServiceTokenVo(
     val accessToken: String,
     val refreshToken: String,
+    val userId: Long,
 ) {
     companion object {
-        fun from(accessToken: String, refreshToken: String): ServiceTokenVo {
+        fun from(accessToken: String, refreshToken: String, userId: Long): ServiceTokenVo {
             return ServiceTokenVo(
                 accessToken = accessToken,
                 refreshToken = refreshToken,
+                userId = userId,
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/SignInVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/SignInVo.kt
@@ -6,6 +6,7 @@ import java.time.LocalDate
 data class SignInVo(
     val accessToken: String,
     val refreshToken: String,
+    val userId: Long,
     val userStatus: String,
     val nickname: String?,
     val birthDay: LocalDate?,
@@ -16,6 +17,7 @@ data class SignInVo(
             return SignInVo(
                 accessToken = serviceToken.accessToken,
                 refreshToken = serviceToken.refreshToken,
+                userId = user.id,
                 userStatus = user.userStatus.name,
                 nickname = user.nickname,
                 birthDay = user.birthDate,

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/sample/service/SampleService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/sample/service/SampleService.kt
@@ -116,6 +116,7 @@ class SampleService(
         return ServiceTokenVo(
             accessToken,
             refreshToken,
+            userId,
         )
     }
 

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
@@ -269,6 +269,7 @@ class AuthServiceTest @Autowired constructor(
 
         // then
         verify(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName), never())!!.evictIfPresent(user.platform.name)
+        assertThat(result.userId).isEqualTo(user.id)
         assertThat(result.nickname).isEqualTo(user.nickname)
         assertThat(result.accessToken).isEqualTo(fakeServiceToken.accessToken)
         assertThat(result.refreshToken).isEqualTo(fakeServiceToken.refreshToken)
@@ -325,6 +326,7 @@ class AuthServiceTest @Autowired constructor(
 
         // then
         verify(oidcCacheManager.getCache(OIDC_PUBLIC_KEY.cacheName), times(1))!!.evictIfPresent(user.platform.name)
+        assertThat(result.userId).isEqualTo(user.id)
         assertThat(result.nickname).isEqualTo(user.nickname)
         assertThat(result.accessToken).isEqualTo(fakeServiceToken.accessToken)
         assertThat(result.refreshToken).isEqualTo(fakeServiceToken.refreshToken)
@@ -380,6 +382,7 @@ class AuthServiceTest @Autowired constructor(
         )
 
         // then
+        assertThat(result.userId).isEqualTo(user.id)
         assertThat(result.nickname).isEqualTo(user.nickname)
         assertThat(result.accessToken).isEqualTo(fakeServiceToken.accessToken)
         assertThat(result.refreshToken).isEqualTo(fakeServiceToken.refreshToken)

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
@@ -103,9 +103,9 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun refresh() {
         // given
-        val oldServiceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken")
-        val deviceId = "test-device"
         val userId = 0L
+        val oldServiceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken", userId = userId)
+        val deviceId = "test-device"
         doReturn(userId)
             .whenever(jwtHelper).extractUserIdIgnoringSignature(oldServiceToken.accessToken)
         doReturn(true)
@@ -129,9 +129,9 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun refresh_WithInvalidRefreshToken_ThrowsException() {
         // given
-        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "invalidRefreshToken")
-        val deviceId = "test-device"
         val userId = 1L
+        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "invalidRefreshToken", userId = userId)
+        val deviceId = "test-device"
         doReturn(userId)
             .whenever(jwtHelper).extractUserIdIgnoringSignature(serviceToken.accessToken)
         doReturn(false)
@@ -151,9 +151,9 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun refresh_WithMismatchedRefreshToken_ThrowsException() {
         // given
-        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken")
-        val deviceId = "test-device"
         val userId = 1L
+        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken", userId = userId)
+        val deviceId = "test-device"
         val storedRefreshToken = "differentRefreshToken"
         doReturn(userId)
             .whenever(jwtHelper).extractUserIdIgnoringSignature(serviceToken.accessToken)
@@ -246,6 +246,7 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
+            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())
@@ -301,6 +302,7 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
+            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())
@@ -358,6 +360,7 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
+            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())
@@ -406,6 +409,7 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
+            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())


### PR DESCRIPTION
## 관련 이슈
- close #279 

## 작업한 내용
- 클라이언트 요청에 따라, 로그인 & 토큰 재발행 API 응답에 user id 추가
- 추가된 api를 security config 등록
