### PR TITLE
[Refactor] token refresh api의 누락된 user status 프로퍼티 추가

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/controller/AuthController.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/controller/AuthController.kt
@@ -128,12 +128,12 @@ class AuthController(
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
         @RequestBody request: ServiceTokenResponse,
     ): CaramelApiResponse<ServiceTokenResponse> {
-        val serviceTokenVo = authService.refresh(
+        val tokenRefreshVo = authService.refresh(
             accessToken = request.accessToken,
             refreshToken = request.refreshToken,
             deviceId = deviceId,
         )
-        return ServiceTokenResponse.from(serviceTokenVo).succeed()
+        return ServiceTokenResponse.from(tokenRefreshVo.serviceTokenVo).succeed()
     }
 
     @DisableSwaggerAuthButton
@@ -158,12 +158,12 @@ class AuthController(
         @RequestHeader(name = DEVICE_ID, required = true) deviceId: String,
         @RequestBody request: ServiceTokenResponse,
     ): CaramelApiResponse<TokenRefreshResponse> {
-        val serviceTokenVo = authService.refresh(
+        val tokenRefreshVo = authService.refresh(
             accessToken = request.accessToken,
             refreshToken = request.refreshToken,
             deviceId = deviceId,
         )
-        return TokenRefreshResponse.from(serviceTokenVo).succeed()
+        return TokenRefreshResponse.from(tokenRefreshVo).succeed()
     }
 
     @Operation(

--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/dto/ServiceTokenResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/auth/dto/ServiceTokenResponse.kt
@@ -1,6 +1,8 @@
 package com.whatever.caramel.api.auth.dto
 
 import com.whatever.caramel.domain.auth.vo.ServiceTokenVo
+import com.whatever.caramel.domain.auth.vo.TokenRefreshVo
+import com.whatever.caramel.domain.user.model.UserStatus
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "api 요청에 사용되는 JWT DTO")
@@ -26,15 +28,15 @@ data class TokenRefreshResponse(
     val serviceToken: ServiceTokenResponse,
     @Schema(description = "토큰 refresh 유저의 고유 ID")
     val userId: Long,
+    @Schema(description = "유저의 현재 상태")
+    val userStatus: UserStatus,
 ) {
     companion object {
-        fun from(serviceTokenVo: ServiceTokenVo): TokenRefreshResponse {
+        fun from(tokenRefreshVo: TokenRefreshVo): TokenRefreshResponse {
             return TokenRefreshResponse(
-                serviceToken = ServiceTokenResponse(
-                    accessToken = serviceTokenVo.accessToken,
-                    refreshToken = serviceTokenVo.refreshToken
-                ),
-                userId = serviceTokenVo.userId,
+                serviceToken = ServiceTokenResponse.from(tokenRefreshVo.serviceTokenVo),
+                userId = tokenRefreshVo.userId,
+                userStatus = tokenRefreshVo.userStatus,
             )
         }
     }

--- a/caramel-api/src/test/kotlin/com/whatever/caramel/api/auth/controller/AuthControllerTest.kt
+++ b/caramel-api/src/test/kotlin/com/whatever/caramel/api/auth/controller/AuthControllerTest.kt
@@ -8,6 +8,7 @@ import com.whatever.caramel.common.global.constants.CaramelHttpHeaders.DEVICE_ID
 import com.whatever.caramel.common.util.DateTimeUtil
 import com.whatever.caramel.domain.auth.vo.ServiceTokenVo
 import com.whatever.caramel.domain.auth.vo.SignInVo
+import com.whatever.caramel.domain.auth.vo.TokenRefreshVo
 import com.whatever.caramel.domain.user.model.LoginPlatform
 import com.whatever.caramel.domain.user.model.UserStatus
 import com.whatever.caramel.security.util.SecurityUtil
@@ -41,6 +42,7 @@ class AuthControllerTest : ControllerTestSupport() {
             SignInVo(
                 accessToken = "",
                 refreshToken = "",
+                userId = 0L,
                 userStatus = UserStatus.SINGLE.name,
                 nickname = "",
                 birthDay = DateTimeUtil.localNow().toLocalDate(),
@@ -98,6 +100,11 @@ class AuthControllerTest : ControllerTestSupport() {
             accessToken = newAccessToken,
             refreshToken = newRefreshToken
         )
+        val newTokenRefreshVo = TokenRefreshVo(
+            serviceTokenVo = newServiceTokenVo,
+            userId = 0L,
+            userStatus = UserStatus.SINGLE,
+        )
 
         whenever(
             authService.refresh(
@@ -105,7 +112,7 @@ class AuthControllerTest : ControllerTestSupport() {
                 refreshToken = requestDto.refreshToken,
                 deviceId = deviceId
             )
-        ).thenReturn(newServiceTokenVo)
+        ).thenReturn(newTokenRefreshVo)
 
         // when // then
         mockMvc.post("/v1/auth/refresh") {

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/service/AuthService.kt
@@ -16,6 +16,7 @@ import com.whatever.caramel.domain.auth.repository.AuthRedisRepository
 import com.whatever.caramel.domain.auth.service.provider.SocialUserProvider
 import com.whatever.caramel.domain.auth.vo.ServiceTokenVo
 import com.whatever.caramel.domain.auth.vo.SignInVo
+import com.whatever.caramel.domain.auth.vo.TokenRefreshVo
 import com.whatever.caramel.domain.couple.service.CoupleService
 import com.whatever.caramel.domain.findByIdAndNotDeleted
 import com.whatever.caramel.domain.user.exception.UserExceptionCode.NOT_FOUND
@@ -74,9 +75,7 @@ class AuthService(
                 )
             }
 
-        val userId = user.id
-
-        val serviceToken = createTokenAndSave(userId = userId, deviceId = deviceId)
+        val serviceToken = createTokenAndSave(userId = user.id, deviceId = deviceId)
         return SignInVo.from(
             serviceToken = serviceToken,
             user = user
@@ -107,11 +106,12 @@ class AuthService(
         logger.debug { "SignOut End - UserId: $userId, DeviceId: $deviceId" }
     }
 
-    fun refresh(accessToken: String, refreshToken: String, deviceId: String): ServiceTokenVo {
+    fun refresh(accessToken: String, refreshToken: String, deviceId: String): TokenRefreshVo {
         val userId = jwtHelper.extractUserIdIgnoringSignature(accessToken)
         val isValid = jwtHelper.isValidJwt(refreshToken)
 
-        if (isValid.not()) throw AuthException(errorCode = AuthExceptionCode.UNAUTHORIZED)
+        val user = userRepository.findByIdAndNotDeleted(userId)
+        if (isValid.not() || user == null) throw AuthException(errorCode = AuthExceptionCode.UNAUTHORIZED)
 
         val localRefreshToken = authRedisRepository.getRefreshToken(userId = userId, deviceId = deviceId)
 
@@ -120,7 +120,12 @@ class AuthService(
         }
         // TODO(준용) access token black list 등록
 
-        return createTokenAndSave(userId = userId, deviceId = deviceId)
+        val serviceTokenVo = createTokenAndSave(userId = userId, deviceId = deviceId)
+        return TokenRefreshVo(
+            serviceTokenVo = serviceTokenVo,
+            userId = user.id,
+            userStatus = user.userStatus,
+        )
     }
 
     @Transactional
@@ -161,7 +166,6 @@ class AuthService(
         return ServiceTokenVo.from(
             accessToken,
             refreshToken,
-            userId,
         )
     }
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/ServiceTokenVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/ServiceTokenVo.kt
@@ -3,14 +3,12 @@ package com.whatever.caramel.domain.auth.vo
 data class ServiceTokenVo(
     val accessToken: String,
     val refreshToken: String,
-    val userId: Long,
 ) {
     companion object {
-        fun from(accessToken: String, refreshToken: String, userId: Long): ServiceTokenVo {
+        fun from(accessToken: String, refreshToken: String): ServiceTokenVo {
             return ServiceTokenVo(
                 accessToken = accessToken,
                 refreshToken = refreshToken,
-                userId = userId,
             )
         }
     }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/TokenRefreshVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/auth/vo/TokenRefreshVo.kt
@@ -1,0 +1,9 @@
+package com.whatever.caramel.domain.auth.vo
+
+import com.whatever.caramel.domain.user.model.UserStatus
+
+data class TokenRefreshVo(
+    val serviceTokenVo: ServiceTokenVo,
+    val userId: Long,
+    val userStatus: UserStatus,
+)

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/sample/service/SampleService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/sample/service/SampleService.kt
@@ -116,7 +116,6 @@ class SampleService(
         return ServiceTokenVo(
             accessToken,
             refreshToken,
-            userId,
         )
     }
 

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/auth/service/AuthServiceTest.kt
@@ -5,7 +5,6 @@ import com.whatever.caramel.common.global.exception.GlobalExceptionCode
 import com.whatever.caramel.common.global.jwt.JwtHelper
 import com.whatever.caramel.common.global.jwt.JwtHelper.Companion.BEARER_TYPE
 import com.whatever.caramel.common.util.DateTimeUtil
-import com.whatever.caramel.config.CacheType
 import com.whatever.caramel.config.CacheType.OIDC_PUBLIC_KEY
 import com.whatever.caramel.domain.CaramelDomainSpringBootTest
 import com.whatever.caramel.domain.auth.exception.AuthException
@@ -103,14 +102,14 @@ class AuthServiceTest @Autowired constructor(
     @Test
     fun refresh() {
         // given
-        val userId = 0L
-        val oldServiceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken", userId = userId)
+        val user = createSingleUser(userRepository)
+        val oldServiceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken")
         val deviceId = "test-device"
-        doReturn(userId)
+        doReturn(user.id)
             .whenever(jwtHelper).extractUserIdIgnoringSignature(oldServiceToken.accessToken)
         doReturn(true)
             .whenever(jwtHelper).isValidJwt(oldServiceToken.refreshToken)
-        whenever(authRedisRepository.getRefreshToken(userId = userId, deviceId = deviceId))
+        whenever(authRedisRepository.getRefreshToken(userId = user.id, deviceId = deviceId))
             .thenReturn(oldServiceToken.refreshToken)
 
         // when
@@ -121,8 +120,10 @@ class AuthServiceTest @Autowired constructor(
         )
 
         // then
-        assertThat(result.accessToken).isNotEqualTo(oldServiceToken.accessToken)
-        assertThat(result.refreshToken).isNotEqualTo(oldServiceToken.refreshToken)
+        with(result.serviceTokenVo) {
+            assertThat(accessToken).isNotEqualTo(oldServiceToken.accessToken)
+            assertThat(refreshToken).isNotEqualTo(oldServiceToken.refreshToken)
+        }
     }
 
     @DisplayName("유효하지 않은 리프레시 토큰이면 예외가 발생한다.")
@@ -130,7 +131,7 @@ class AuthServiceTest @Autowired constructor(
     fun refresh_WithInvalidRefreshToken_ThrowsException() {
         // given
         val userId = 1L
-        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "invalidRefreshToken", userId = userId)
+        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "invalidRefreshToken")
         val deviceId = "test-device"
         doReturn(userId)
             .whenever(jwtHelper).extractUserIdIgnoringSignature(serviceToken.accessToken)
@@ -152,7 +153,7 @@ class AuthServiceTest @Autowired constructor(
     fun refresh_WithMismatchedRefreshToken_ThrowsException() {
         // given
         val userId = 1L
-        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken", userId = userId)
+        val serviceToken = ServiceTokenVo(accessToken = "accessToken", refreshToken = "refreshToken")
         val deviceId = "test-device"
         val storedRefreshToken = "differentRefreshToken"
         doReturn(userId)
@@ -246,7 +247,6 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
-            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())
@@ -302,7 +302,6 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
-            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())
@@ -360,7 +359,6 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
-            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())
@@ -409,7 +407,6 @@ class AuthServiceTest @Autowired constructor(
         val fakeServiceToken = ServiceTokenVo(
             accessToken = "test-access-token",
             refreshToken = "test-refresh-token",
-            userId = user.id,
         )
 
         whenever(kakaoOIDCClient.getOIDCPublicKey())


### PR DESCRIPTION
## 관련 이슈
- close #282 

## 작업한 내용
- #279 에 추가했던 ServiceTokenVo에서 userId 프로퍼티를 제거하고, TokenRefreshVo를 새로 추가해 반환했습니다.
- user status 조회가 필요함에 따라 `AuthService.refresh()`에 userRepository 조회가 추가되었습니다.
