### PR TITLE
[Fix] 배치 로직 수정

### DIFF
--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -30,6 +30,8 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.retry.backoff.FixedBackOffPolicy
 import org.springframework.transaction.PlatformTransactionManager
 import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 @Configuration
 class AnniversaryFcmBatchConfig(
@@ -42,7 +44,7 @@ class AnniversaryFcmBatchConfig(
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         @Value("#{jobParameters['runDate']}") runDate: LocalDate,
     ): JpaPagingItemReader<ScheduledNotification> {
-        val startOfDay = runDate.atStartOfDay()
+        val startOfDay = runDate.plusDays(1).atStartOfDay()
         val endOfDay = startOfDay.plusDays(1).withNano(0)
 
         return JpaPagingItemReaderBuilder<ScheduledNotification>()
@@ -51,7 +53,8 @@ class AnniversaryFcmBatchConfig(
             .queryString(
                 """
                     SELECT s FROM ScheduledNotification s 
-                    WHERE s.notifyAt BETWEEN :startOfDay AND :endOfDay
+                    WHERE s.notifyAt >= :startOfDay 
+                    AND s.notifyAt < :endOfDay
                     ORDER BY s.id
                     """.trimIndent()
             )

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -32,7 +32,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import java.time.LocalDate
 
 @Configuration
-class AnniversaryBatchConfig(
+class AnniversaryFcmBatchConfig(
     private val whatEverJobRepository: JobRepository,
     private val apiEntityManagerFactory: EntityManagerFactory,
 ) {

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -30,8 +30,6 @@ import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.retry.backoff.FixedBackOffPolicy
 import org.springframework.transaction.PlatformTransactionManager
 import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZoneOffset
 
 @Configuration
 class AnniversaryFcmBatchConfig(

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -44,7 +44,7 @@ class AnniversaryFcmBatchConfig(
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         @Value("#{jobParameters['runDate']}") runDate: LocalDate,
     ): JpaPagingItemReader<ScheduledNotification> {
-        val startOfDay = runDate.plusDays(1).atStartOfDay()
+        val startOfDay = runDate.atStartOfDay()
         val endOfDay = startOfDay.plusDays(1).withNano(0)
 
         return JpaPagingItemReaderBuilder<ScheduledNotification>()

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/ScheduleNotificationAddBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/ScheduleNotificationAddBatchConfig.kt
@@ -36,6 +36,7 @@ class ScheduleNotificationAddBatchConfig(
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         @Value("#{jobParameters['runDate']}") runDate: LocalDate,
     ): JpaPagingItemReader<User> {
+        // KST 기준, 내일이 생일인 유저를 read
         val tomorrow = runDate.plusDays(1)
 
         val year = tomorrow.year
@@ -86,11 +87,8 @@ class ScheduleNotificationAddBatchConfig(
         return ItemProcessor<User, List<ScheduledNotification>> { user ->
             val partner = user.couple?.members?.find { it.id != user.id } ?: return@ItemProcessor null
 
-            val birthDate = user.birthDate ?: return@ItemProcessor null
-            val thisYearsBirthday = birthDate.withYear(runDate.year)
-
-            // 하루 전에 알림을 날림
-            val notifyAt = thisYearsBirthday.minusDays(1).atStartOfDay()
+            // 생일 하루 전날 23:40에 알림을 날림
+            val notifyAt = runDate.atTime(23, 40)
 
             val nickname = user.nickname ?: return@ItemProcessor null
             val birthdayUserMessage = messageProvider.provide(

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/ScheduleNotificationAddBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/ScheduleNotificationAddBatchConfig.kt
@@ -36,7 +36,7 @@ class ScheduleNotificationAddBatchConfig(
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         @Value("#{jobParameters['runDate']}") runDate: LocalDate,
     ): JpaPagingItemReader<User> {
-        val tomorrow = runDate.plusDays(1)
+        val tomorrow = runDate.plusDays(2) // runDate 수행이 UST 기준이라 2일 뒤에서 찾습니다
 
         val year = tomorrow.year
         val month = tomorrow.monthValue

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/ScheduleNotificationAddBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/ScheduleNotificationAddBatchConfig.kt
@@ -36,7 +36,7 @@ class ScheduleNotificationAddBatchConfig(
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         @Value("#{jobParameters['runDate']}") runDate: LocalDate,
     ): JpaPagingItemReader<User> {
-        val tomorrow = runDate.plusDays(2) // runDate 수행이 UST 기준이라 2일 뒤에서 찾습니다
+        val tomorrow = runDate.plusDays(1)
 
         val year = tomorrow.year
         val month = tomorrow.monthValue
@@ -89,7 +89,7 @@ class ScheduleNotificationAddBatchConfig(
             val birthDate = user.birthDate ?: return@ItemProcessor null
             val thisYearsBirthday = birthDate.withYear(runDate.year)
 
-            // 하루 전에 알림을 날릴 예정
+            // 하루 전에 알림을 날림
             val notifyAt = thisYearsBirthday.minusDays(1).atStartOfDay()
 
             val nickname = user.nickname ?: return@ItemProcessor null


### PR DESCRIPTION
## 관련 이슈
- 생일 당일에 배치가 보내지는 이슈

## 작업한 내용
- 외부에서 runDate를 주입 받으면서 발생한 이슈에요
FCM을 보내는 시간은 UST 14:30, KST 23:40 이라서 날짜가 같기 때문에 오늘 notifyAt 인 유저를 바라보고 보냅니다
그런데, 디비에는 시간정보가 없어서 Between인 경우 다음날 생일인 유저까지 포함될 수 있어서 < 로 변경
예를들어 11-11, 11-12 가 생일인 경우 between a and b 면 12도 포함될 수 있어서 < 로 변경

- notifyAt 로직 단순화 했어요 
오늘 보내야하니 그냥 runDate 그대로 씀

## PR 포인트
- 