### PR TITLE
[Fix] Retry 로직 제거

### DIFF
--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -8,6 +8,7 @@ import com.whatever.caramel.domain.notification.model.ScheduledNotification
 import com.whatever.caramel.domain.notification.repository.ScheduledNotificationRepository
 import com.whatever.caramel.infrastructure.firebase.exception.FcmException
 import com.whatever.caramel.infrastructure.firebase.exception.FcmIllegalArgumentException
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendException
 import com.whatever.caramel.infrastructure.firebase.model.FcmNotification
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
@@ -116,14 +117,8 @@ class AnniversaryFcmBatchConfig(
             .processor(anniversaryItemProcessor)
             .writer(anniversaryItemWriter)
             .faultTolerant()
-            .retry(FcmException::class.java)
-            .noRetry(FcmIllegalArgumentException::class.java)
-            .retryLimit(2)
-            .backOffPolicy(FixedBackOffPolicy().apply {
-                backOffPeriod = 500L
-            })
             .processorNonTransactional() // processor 에서 딱히 실패할만한 요소는 보이지 않지만 넣어둠
-            .skip(FcmException::class.java)
+            .skip(FcmSendException::class.java)
             .skipPolicy(AlwaysSkipItemSkipPolicy())
             .listener(anniversaryStepListener)
             .build()


### PR DESCRIPTION
## 관련 이슈
- 알림이 3개간 이유는?

## 작업한 내용
- retryLimit(2) 때문에, FcmException이 발생하면 1회 실패, 2회 재시도를 통해 3회의 알림이 갔네요
- 근데 아래 보면 UNREGISTERD, NOT_FOUND 인데, 왜 FCM 이 날라갔는지는 모르겠어요 
- 이게 test flight로 여러개 설치하고 지우다 보니 토큰이 만료됐나 싶긴한데요, 만료됐음 안가야 하지 않나.. 왜갔을까요 아시는분?

```
FCM ErrorCode: UNREGISTERED, MappedCode: FCM_UNREGISTERED_TOKEN

com.google.firebase.messaging.FirebaseMessagingException: Requested entity was not found.
	at com.google.firebase.messaging.FirebaseMessagingException.withMessagingErrorCode(FirebaseMessagingException.java:51) ~[firebase-admin-9.4.3.jar!/:?]
	at com.google.firebase.messaging.FirebaseMessagingClientImpl$MessagingErrorHandler 
...

Caused by: com.google.api.client.http.HttpResponseException: 404 Not Found
POST https://fcm.googleapis.com/v1/projects/caramel-b6339/messages:send
{
  "error": {
    "code": 404,
    "message": "Requested entity was not found.",
    "status": "NOT_FOUND",
    "details": [
      {
        "@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError",
        "errorCode": "UNREGISTERED"
      }
    ]
  }
}

```

## PR 포인트
- 