### PR TITLE
[Fix] retry 수정

### DIFF
--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -7,8 +7,6 @@ import com.whatever.caramel.domain.firebase.service.FirebaseService
 import com.whatever.caramel.domain.notification.model.ScheduledNotification
 import com.whatever.caramel.domain.notification.repository.ScheduledNotificationRepository
 import com.whatever.caramel.infrastructure.firebase.exception.FcmException
-import com.whatever.caramel.infrastructure.firebase.exception.FcmIllegalArgumentException
-import com.whatever.caramel.infrastructure.firebase.exception.FcmSendException
 import com.whatever.caramel.infrastructure.firebase.model.FcmNotification
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
@@ -28,7 +26,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.annotation.DateTimeFormat
-import org.springframework.retry.backoff.FixedBackOffPolicy
 import org.springframework.transaction.PlatformTransactionManager
 import java.time.LocalDate
 
@@ -118,8 +115,8 @@ class AnniversaryFcmBatchConfig(
             .writer(anniversaryItemWriter)
             .faultTolerant()
             .processorNonTransactional() // processor 에서 딱히 실패할만한 요소는 보이지 않지만 넣어둠
-            .skip(FcmSendException::class.java)
             .skipPolicy(AlwaysSkipItemSkipPolicy())
+            .noRetry(FcmException::class.java)
             .listener(anniversaryStepListener)
             .build()
     }


### PR DESCRIPTION
## 관련 이슈
- FCM Message Exception이 났을 때 재시도하여 FCM이 여러개 나가는 이슈

## 작업한 내용
- FCM exception은 재시도 하지 않도록 noRetry를 사용했어요
- 기존에 3개, 2개가 나갔던 이유는, 배치는 에러가 나면 retry -> skip 순으로 진행한다고 합니다
- 근데 아무런 세팅을 해주지 않으면, 기본 재시도를 3회까지 진행하기 때문에 여러개 FCM이 나간 것 같습니다~

<img width="470" height="200" alt="image" src="https://github.com/user-attachments/assets/3c86345d-0040-4d96-8ec3-b1194689299b" />

## PR 포인트
- 배치쪽에서 UNREGISTER를 받았다면 서버에 토큰을 지우는 로직을 추가해볼까요~?