### PR TITLE
[Refactor] Unregister인 토큰 제거

### DIFF
--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/exception/BatchUnregisteredException.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/exception/BatchUnregisteredException.kt
@@ -1,0 +1,11 @@
+package com.whatever.caramel.batch.config.exception
+
+import com.whatever.caramel.common.global.exception.common.CaramelExceptionCode
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendFailedReason
+
+class BatchUnregisteredException(
+    val tokens: List<FcmSendFailedReason>,
+    val errorCode: CaramelExceptionCode,
+) : CaramelBatchException()
+
+open class CaramelBatchException : Exception()

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -3,8 +3,8 @@ package com.whatever.caramel.batch.config.job
 import com.whatever.caramel.batch.config.exception.BatchUnregisteredException
 import com.whatever.caramel.batch.config.exception.CaramelBatchException
 import com.whatever.caramel.batch.config.listener.AnniversaryJobListener
+import com.whatever.caramel.batch.config.listener.AnniversarySkipListener
 import com.whatever.caramel.batch.config.listener.AnniversaryStepListener
-import com.whatever.caramel.batch.config.skip.FcmSkipPolicy
 import com.whatever.caramel.batch.entity.BatchFcmNotification
 import com.whatever.caramel.domain.firebase.service.FirebaseService
 import com.whatever.caramel.domain.notification.model.ScheduledNotification
@@ -19,6 +19,7 @@ import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.core.step.skip.AlwaysSkipItemSkipPolicy
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemReader
 import org.springframework.batch.item.ItemWriter
@@ -36,6 +37,7 @@ import java.time.LocalDate
 class AnniversaryFcmBatchConfig(
     private val whatEverJobRepository: JobRepository,
     private val apiEntityManagerFactory: EntityManagerFactory,
+    private val firebaseService: FirebaseService,
 ) {
     @Bean
     @StepScope
@@ -84,9 +86,7 @@ class AnniversaryFcmBatchConfig(
     }
 
     @Bean
-    fun anniversaryItemWriter(
-        firebaseService: FirebaseService,
-    ): ItemWriter<BatchFcmNotification> {
+    fun anniversaryItemWriter(): ItemWriter<BatchFcmNotification> {
         return ItemWriter { chunk ->
             chunk.items.forEach { notification ->
                 with(notification) {
@@ -119,7 +119,7 @@ class AnniversaryFcmBatchConfig(
         anniversaryItemProcessor: ItemProcessor<ScheduledNotification, BatchFcmNotification>,
         anniversaryItemWriter: ItemWriter<BatchFcmNotification>,
         anniversaryStepListener: AnniversaryStepListener,
-        firebaseService: FirebaseService,
+        anniversarySkipListener: AnniversarySkipListener,
     ): Step {
         return StepBuilder("anniversaryStep", whatEverJobRepository)
             .chunk<ScheduledNotification, BatchFcmNotification>(FCM_CHUNK_SIZE, transactionManager)
@@ -128,10 +128,11 @@ class AnniversaryFcmBatchConfig(
             .writer(anniversaryItemWriter)
             .faultTolerant()
             .processorNonTransactional() // processor 에서 딱히 실패할만한 요소는 보이지 않지만 넣어둠
-            .skipPolicy(FcmSkipPolicy(firebaseService))
+            .skipPolicy(AlwaysSkipItemSkipPolicy())
             .noRetry(FcmException::class.java)
             .noRetry(CaramelBatchException::class.java)
             .listener(anniversaryStepListener)
+            .listener(anniversarySkipListener)
             .build()
     }
 

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/job/AnniversaryFcmBatchConfig.kt
@@ -1,12 +1,16 @@
 package com.whatever.caramel.batch.config.job
 
+import com.whatever.caramel.batch.config.exception.BatchUnregisteredException
+import com.whatever.caramel.batch.config.exception.CaramelBatchException
 import com.whatever.caramel.batch.config.listener.AnniversaryJobListener
 import com.whatever.caramel.batch.config.listener.AnniversaryStepListener
+import com.whatever.caramel.batch.config.skip.FcmSkipPolicy
 import com.whatever.caramel.batch.entity.BatchFcmNotification
 import com.whatever.caramel.domain.firebase.service.FirebaseService
 import com.whatever.caramel.domain.notification.model.ScheduledNotification
 import com.whatever.caramel.domain.notification.repository.ScheduledNotificationRepository
 import com.whatever.caramel.infrastructure.firebase.exception.FcmException
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendException
 import com.whatever.caramel.infrastructure.firebase.model.FcmNotification
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
@@ -15,7 +19,6 @@ import org.springframework.batch.core.configuration.annotation.StepScope
 import org.springframework.batch.core.job.builder.JobBuilder
 import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
-import org.springframework.batch.core.step.skip.AlwaysSkipItemSkipPolicy
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemReader
 import org.springframework.batch.item.ItemWriter
@@ -85,16 +88,25 @@ class AnniversaryFcmBatchConfig(
         firebaseService: FirebaseService,
     ): ItemWriter<BatchFcmNotification> {
         return ItemWriter { chunk ->
-            chunk.items.map { notification ->
+            chunk.items.forEach { notification ->
                 with(notification) {
-                    firebaseService.sendNotification(
-                        setOf(targetId),
-                        FcmNotification(
-                            title = fcmNotification.title,
-                            body = fcmNotification.body,
-                            image = fcmNotification.image,
+                    runCatching {
+                        firebaseService.sendNotification(
+                            setOf(targetId),
+                            FcmNotification(
+                                title = fcmNotification.title,
+                                body = fcmNotification.body,
+                                image = fcmNotification.image,
+                            )
                         )
-                    )
+                    }.onFailure { exception ->
+                        if (exception is FcmSendException && exception.tokens.isNotEmpty()) {
+                            throw BatchUnregisteredException(
+                                tokens = exception.tokens,
+                                errorCode = exception.errorCode,
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -107,6 +119,7 @@ class AnniversaryFcmBatchConfig(
         anniversaryItemProcessor: ItemProcessor<ScheduledNotification, BatchFcmNotification>,
         anniversaryItemWriter: ItemWriter<BatchFcmNotification>,
         anniversaryStepListener: AnniversaryStepListener,
+        firebaseService: FirebaseService,
     ): Step {
         return StepBuilder("anniversaryStep", whatEverJobRepository)
             .chunk<ScheduledNotification, BatchFcmNotification>(FCM_CHUNK_SIZE, transactionManager)
@@ -115,8 +128,9 @@ class AnniversaryFcmBatchConfig(
             .writer(anniversaryItemWriter)
             .faultTolerant()
             .processorNonTransactional() // processor 에서 딱히 실패할만한 요소는 보이지 않지만 넣어둠
-            .skipPolicy(AlwaysSkipItemSkipPolicy())
+            .skipPolicy(FcmSkipPolicy(firebaseService))
             .noRetry(FcmException::class.java)
+            .noRetry(CaramelBatchException::class.java)
             .listener(anniversaryStepListener)
             .build()
     }

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/listener/AnniversarySkipListener.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/listener/AnniversarySkipListener.kt
@@ -1,7 +1,9 @@
-package com.whatever.caramel.batch.config.skip
+package com.whatever.caramel.batch.config.listener
 
 import com.whatever.caramel.batch.config.exception.BatchUnregisteredException
+import com.whatever.caramel.batch.entity.BatchFcmNotification
 import com.whatever.caramel.domain.firebase.service.FirebaseService
+import com.whatever.caramel.domain.notification.model.ScheduledNotification
 import com.whatever.caramel.infrastructure.firebase.exception.FcmSendFailedReason
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_BLANK_TOKEN
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_EMPTY_TOKEN
@@ -14,21 +16,22 @@ import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionC
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_THIRD_PARTY_AUTH_ERROR
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_UNREGISTERED_TOKEN
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.UNKNOWN
-import org.springframework.batch.core.step.skip.SkipPolicy
+import org.springframework.batch.core.SkipListener
+import org.springframework.stereotype.Component
 
-class FcmSkipPolicy(
+@Component
+class AnniversarySkipListener(
     private val fcmTokenService: FirebaseService,
-) : SkipPolicy {
+) : SkipListener<ScheduledNotification, BatchFcmNotification> {
 
-    override fun shouldSkip(throwable: Throwable, skipCount: Long): Boolean {
-        if (throwable !is BatchUnregisteredException) return true
+    override fun onSkipInWrite(item: BatchFcmNotification, throwable: Throwable) {
+        if (throwable !is BatchUnregisteredException) return
 
         if (throwable.errorCode == FCM_UNREGISTERED_TOKEN || throwable.errorCode == FCM_MULTIPLE_TOKEN_ERROR) {
             throwable.tokens.forEach { fcmToken ->
                 checkUnregisterToken(fcmToken)
             }
         }
-        return true
     }
 
     private fun checkUnregisterToken(fcmToken: FcmSendFailedReason) {

--- a/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/skip/FcmSkipPolicy.kt
+++ b/caramel-batch/src/main/kotlin/com/whatever/caramel/batch/config/skip/FcmSkipPolicy.kt
@@ -1,0 +1,54 @@
+package com.whatever.caramel.batch.config.skip
+
+import com.whatever.caramel.batch.config.exception.BatchUnregisteredException
+import com.whatever.caramel.domain.firebase.service.FirebaseService
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendFailedReason
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_BLANK_TOKEN
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_EMPTY_TOKEN
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_INTERNAL_SERVER_ERROR
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_INVALID_ARGUMENT
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_MULTIPLE_TOKEN_ERROR
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_QUOTA_EXCEEDED
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_SENDER_ID_MISMATCH
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_SERVER_UNAVAILABLE
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_THIRD_PARTY_AUTH_ERROR
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_UNREGISTERED_TOKEN
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.UNKNOWN
+import org.springframework.batch.core.step.skip.SkipPolicy
+
+class FcmSkipPolicy(
+    private val fcmTokenService: FirebaseService,
+) : SkipPolicy {
+
+    override fun shouldSkip(throwable: Throwable, skipCount: Long): Boolean {
+        if (throwable !is BatchUnregisteredException) return true
+
+        if (throwable.errorCode == FCM_UNREGISTERED_TOKEN || throwable.errorCode == FCM_MULTIPLE_TOKEN_ERROR) {
+            throwable.tokens.forEach { fcmToken ->
+                checkUnregisterToken(fcmToken)
+            }
+        }
+        return true
+    }
+
+    private fun checkUnregisterToken(fcmToken: FcmSendFailedReason) {
+        when (fcmToken.errorMessageCode) {
+            FCM_UNREGISTERED_TOKEN -> {
+                fcmTokenService.removeToken(fcmToken.errorToken)
+            }
+
+            UNKNOWN,
+            FCM_EMPTY_TOKEN,
+            FCM_INVALID_ARGUMENT,
+            FCM_SERVER_UNAVAILABLE,
+            FCM_INTERNAL_SERVER_ERROR,
+            FCM_QUOTA_EXCEEDED,
+            FCM_SENDER_ID_MISMATCH,
+            FCM_THIRD_PARTY_AUTH_ERROR,
+            FCM_BLANK_TOKEN,
+            FCM_MULTIPLE_TOKEN_ERROR -> {
+                /** no-op **/
+            }
+        }
+    }
+}

--- a/caramel-batch/src/test/kotlin/com/whatever/caramel/batch/e2e/AnniversaryJobTest.kt
+++ b/caramel-batch/src/test/kotlin/com/whatever/caramel/batch/e2e/AnniversaryJobTest.kt
@@ -1,9 +1,18 @@
 package com.whatever.caramel.batch.e2e
 
+import com.whatever.caramel.common.global.exception.ErrorUi
+import com.whatever.caramel.domain.firebase.service.FirebaseService
 import com.whatever.caramel.domain.notification.repository.ScheduledNotificationRepository
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendException
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendFailedReason
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode
 import jakarta.annotation.PostConstruct
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.batch.core.BatchStatus
 import org.springframework.batch.core.ExitStatus
 import org.springframework.batch.core.Job
@@ -13,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -25,14 +35,18 @@ class AnniversaryJobTest @Autowired constructor(
     private val anniversaryJob: Job,
     private val scheduledNotificationRepository: ScheduledNotificationRepository,
 ) {
+    @MockitoBean
+    lateinit var firebaseService: FirebaseService
+
     @PostConstruct
     fun setUp() {
         jobLauncherTestUtils.job = anniversaryJob
-        insertScheduleNotification()
     }
 
     @Test
     fun `anniversaryJob 배치 성공 테스트`() {
+        insertScheduleNotification()
+
         val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
             .addString("runDate", LocalDate.now(ZoneId.of("Asia/Seoul")).toString())
             .toJobParameters()
@@ -57,6 +71,48 @@ class AnniversaryJobTest @Autowired constructor(
                 assertThat(stepExecution.writeCount).isEqualTo(4)
             }
         }
+    }
+
+    @Test
+    fun `anniversaryJob 중 firebase 토큰이 FCM_UNREGISTERED_TOKEN 를 받으면 removeToken이 호출된다`() {
+        jdbcTemplate.batchUpdate(
+            "INSERT INTO scheduled_notification (target_user_id, notification_type, notify_at, title, body, image, created_at, updated_at)" +
+                "VALUES (?, 'MY_BIRTHDAY', CURRENT_TIMESTAMP, 'title', 'body', null, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            listOf(
+                arrayOf(1L),
+            )
+        )
+        val invalidToken = "invalid-token"
+
+        whenever(firebaseService.sendNotification(any(), any()))
+            .thenThrow(
+                FcmSendException(
+                    tokens = listOf(
+                        FcmSendFailedReason(
+                            errorToken = invalidToken,
+                            errorMessageCode = FirebaseExceptionCode.FCM_UNREGISTERED_TOKEN,
+                        )
+                    ),
+                    errorCode = FirebaseExceptionCode.FCM_UNREGISTERED_TOKEN,
+                    errorUi = ErrorUi.Toast("알림을 전송에 실패했어요.")
+                )
+            )
+
+        val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
+            .addString("runDate", LocalDate.now(ZoneId.of("Asia/Seoul")).toString())
+            .toJobParameters()
+
+        // 기존에 1개가 들어있다고 가정
+        val before = scheduledNotificationRepository.findAll()
+        assertThat(before.count()).isEqualTo(1)
+
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        assertThat(jobExecution.status).isEqualTo(BatchStatus.COMPLETED)
+        assertThat(jobExecution.exitStatus).isEqualTo(ExitStatus.COMPLETED)
+
+        verify(firebaseService, times(1))
+            .removeToken(invalidToken)
     }
 
     private fun insertScheduleNotification() {

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/firebase/repository/FcmTokenRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/firebase/repository/FcmTokenRepository.kt
@@ -3,6 +3,7 @@ package com.whatever.caramel.domain.firebase.repository
 import com.whatever.caramel.common.util.DateTimeUtil
 import com.whatever.caramel.domain.firebase.model.FcmToken
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
@@ -23,4 +24,12 @@ interface FcmTokenRepository : JpaRepository<FcmToken, Long> {
         userIds: Set<Long>,
         expireDateTime: LocalDateTime = DateTimeUtil.localNow().minusDays(270),
     ): List<FcmToken>
+
+    @Modifying
+    @Query(
+        """
+        delete from FcmToken tk where tk._token = :token
+    """
+    )
+    fun deleteFcmTokensByToken(token: String)
 }

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/firebase/repository/FcmTokenRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/firebase/repository/FcmTokenRepository.kt
@@ -25,7 +25,7 @@ interface FcmTokenRepository : JpaRepository<FcmToken, Long> {
         expireDateTime: LocalDateTime = DateTimeUtil.localNow().minusDays(270),
     ): List<FcmToken>
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query(
         """
         delete from FcmToken tk where tk._token = :token

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/firebase/service/FirebaseService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/firebase/service/FirebaseService.kt
@@ -100,4 +100,9 @@ class FirebaseService(
             )
         }
     }
+
+    @Transactional
+    fun removeToken(fcmToken: String) {
+        fcmTokenRepository.deleteFcmTokensByToken(fcmToken)
+    }
 }

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/firebase/FcmSender.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/firebase/FcmSender.kt
@@ -1,5 +1,6 @@
 package com.whatever.caramel.infrastructure.firebase
 
+import com.google.firebase.messaging.BatchResponse
 import com.google.firebase.messaging.FirebaseMessaging
 import com.google.firebase.messaging.FirebaseMessagingException
 import com.google.firebase.messaging.Message
@@ -13,9 +14,12 @@ import com.google.firebase.messaging.MulticastMessage
 import com.whatever.caramel.common.global.exception.ErrorUi
 import com.whatever.caramel.infrastructure.firebase.exception.FcmIllegalArgumentException
 import com.whatever.caramel.infrastructure.firebase.exception.FcmSendException
+import com.whatever.caramel.infrastructure.firebase.exception.FcmSendFailedReason
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_EMPTY_TOKEN
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_INTERNAL_SERVER_ERROR
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_INVALID_ARGUMENT
+import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_MULTIPLE_TOKEN_ERROR
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_QUOTA_EXCEEDED
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_SENDER_ID_MISMATCH
 import com.whatever.caramel.infrastructure.firebase.exception.FirebaseExceptionCode.FCM_SERVER_UNAVAILABLE
@@ -76,7 +80,7 @@ class FcmSender {
             .setToken(token)
             .build()
 
-        return executeFcmCall("sendData to token: $token") {
+        return executeFcmCall("sendData to token: $token", listOf(token)) {
             FirebaseMessaging.getInstance().send(message)
         }
     }
@@ -98,43 +102,85 @@ class FcmSender {
             .addAllTokens(tokens)
             .build()
 
-        return executeFcmCall("sendDataAll to ${tokens.size} tokens") {
+        return executeFcmCall("sendDataAll to ${tokens.size} tokens", tokens) {
             FirebaseMessaging.getInstance().sendEachForMulticast(message)
         }
     }
 
     private fun <T> executeFcmCall(
         callDescription: String,
+        tokens: List<String> = emptyList(),
         fcmCall: () -> T,
     ): T {
         try {
-            return fcmCall()
+            val call = fcmCall()
+
+            if (call is BatchResponse) {
+                val failedTokens = call.responses.mapIndexedNotNull { index, sendResponse ->
+                    if (sendResponse.isSuccessful.not()) {
+                        sendResponse.exception?.let {
+                            logger.error(sendResponse.exception) {
+                                "Multicast failure for token=${tokens[index]}, FCM error=${sendResponse.exception.messagingErrorCode}"
+                            }
+                        }
+
+                        FcmSendFailedReason(
+                            errorToken = tokens[index],
+                            errorMessageCode = mapToCaramelError(sendResponse.exception),
+                        )
+                    } else {
+                        null
+                    }
+                }
+
+                if (failedTokens.isNotEmpty()) {
+                    throw FcmSendException(
+                        tokens = failedTokens,
+                        errorCode = FCM_MULTIPLE_TOKEN_ERROR,
+                        errorUi = ErrorUi.Toast("일부 알림 전송에 실패했어요.")
+                    )
+                }
+            }
+
+            return call
+        } catch (e: FcmSendException) {
+            throw e
         } catch (e: FirebaseMessagingException) {
             //
-            val mappedCode =
-                when (e.messagingErrorCode) {
-                    INVALID_ARGUMENT -> FCM_INVALID_ARGUMENT
-                    UNREGISTERED -> FCM_UNREGISTERED_TOKEN
-                    SENDER_ID_MISMATCH -> FCM_SENDER_ID_MISMATCH
-                    QUOTA_EXCEEDED -> FCM_QUOTA_EXCEEDED
-                    UNAVAILABLE -> FCM_SERVER_UNAVAILABLE
-                    INTERNAL -> FCM_INTERNAL_SERVER_ERROR
-                    else -> UNKNOWN
-                }
+            val mappedCode = mapToCaramelError(e)
             logger.error(e) {
                 "FCM call failed: $callDescription. FCM ErrorCode: ${e.messagingErrorCode}, MappedCode: $mappedCode"
             }
 
             throw FcmSendException(
+                tokens = listOf(
+                    FcmSendFailedReason(
+                        errorToken = tokens.firstOrNull().orEmpty(),
+                        errorMessageCode = mappedCode,
+                    )
+                ),
                 errorCode = mappedCode,
                 errorUi = ErrorUi.Toast("알림을 전송에 실패했어요.")
             )
         } catch (e: Exception) {
             logger.error(e) { "Generic error during FCM call: $callDescription" }
             throw FcmSendException(
+                tokens = emptyList(),
                 errorCode = UNKNOWN,
                 errorUi = ErrorUi.Toast("알림을 전송에 실패했어요.")
             )
+        }
+    }
+
+    private fun mapToCaramelError(e: FirebaseMessagingException): FirebaseExceptionCode {
+        return when (e.messagingErrorCode) {
+            INVALID_ARGUMENT -> FCM_INVALID_ARGUMENT
+            UNREGISTERED -> FCM_UNREGISTERED_TOKEN
+            SENDER_ID_MISMATCH -> FCM_SENDER_ID_MISMATCH
+            QUOTA_EXCEEDED -> FCM_QUOTA_EXCEEDED
+            UNAVAILABLE -> FCM_SERVER_UNAVAILABLE
+            INTERNAL -> FCM_INTERNAL_SERVER_ERROR
+            else -> UNKNOWN
         }
     }
 }

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/firebase/exception/FirebaseException.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/firebase/exception/FirebaseException.kt
@@ -19,6 +19,12 @@ class FcmIllegalArgumentException(
 ) : FcmException(errorCode, errorUi)
 
 class FcmSendException(
+    val tokens: List<FcmSendFailedReason> = emptyList(),
     errorCode: FirebaseExceptionCode,
     errorUi: ErrorUi,
 ) : FcmException(errorCode, errorUi)
+
+class FcmSendFailedReason(
+    val errorToken: String,
+    val errorMessageCode: FirebaseExceptionCode,
+)

--- a/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/firebase/exception/FirebaseExceptionCode.kt
+++ b/caramel-infrastructure/src/main/kotlin/com/whatever/caramel/infrastructure/firebase/exception/FirebaseExceptionCode.kt
@@ -63,6 +63,11 @@ enum class FirebaseExceptionCode(
         sequence = "010",
         message = "FCM 토큰은 Blank일 수 없습니다.",
     ),
+    FCM_MULTIPLE_TOKEN_ERROR(
+        sequence = "011",
+        message = "FCM 토큰 중 하나에서 오류가 발생했습니다.",
+        status = INTERNAL_SERVER_ERROR,
+    )
     ;
 
     override val code = "FIREBASE$sequence"


### PR DESCRIPTION
## 관련 이슈
- fcm 전송중에 unregister 된 토큰은 제거하도록 했습니다
- 근데, 한개가 아닌 multicast로 여러개 전송시에, 에러를 내지 않고 BatchResponse로 반환한다고 합니다.

## 작업한 내용
- 그래서, send 쪽에 에러 로깅은 결국 single로 보낼때만 동작하는 것 같아서 로직에서 throw를 한번 더 하도록 수정
- 배치쪽에서 FcmSendException을 받으면 BatchUnregisteredException로 재 파싱해서, 에러코드가 FCM_UNREGISTERED_TOKEN 라면 해당 코드를 디비에서 찾아서 제거하도록 수정

## PR 포인트
- 배치쪽 로직이 이해가 안가신다면 말씀해주세용 설명해드릴게요~! 
- fcm send 쪽 코드도 수정해서, 문제가 없을지 한번 봐주세요 ~