### PR TITLE
[Refactor] 유저 성별정보를 응답에 추가, 히스토리 조회 조건 변경

### DIFF
--- a/caramel-api/src/main/kotlin/com/whatever/caramel/api/balancegame/controller/dto/response/GetBalanceGameResponse.kt
+++ b/caramel-api/src/main/kotlin/com/whatever/caramel/api/balancegame/controller/dto/response/GetBalanceGameResponse.kt
@@ -29,8 +29,14 @@ data class GetBalanceGameResponse(
                 partnerChoice?.let { gameVo.options.firstOrNull { it.id == partnerChoice.balanceGameOptionId } }
             return GetBalanceGameResponse(
                 gameInfo = BalanceGameInfo.of(gameVo, gameVo.options),
-                myChoice = myChoiceOptionVo?.let { OptionInfo.from(it) },
-                partnerChoice = partnerChoiceOptionVo?.let { OptionInfo.from(it) }
+                myChoice = myChoiceOptionVo?.let { OptionInfo.from(
+                    it,
+                    myChoice.gender.toString(),
+                ) },
+                partnerChoice = partnerChoiceOptionVo?.let { OptionInfo.from(
+                    it,
+                    partnerChoice.gender.toString(),
+                ) },
             )
         }
     }
@@ -72,12 +78,19 @@ data class OptionInfo(
 
     @Schema(description = "선택지 내용")
     val text: String,
+
+    @Schema(description = "선택한 유저의 성별")
+    val gender: String?,
 ) {
     companion object {
-        fun from(option: BalanceGameOptionVo): OptionInfo {
+        fun from(
+            option: BalanceGameOptionVo,
+            gender: String? = null,
+        ): OptionInfo {
             return OptionInfo(
                 id = option.id,
-                text = option.optionText
+                text = option.optionText,
+                gender = gender,
             )
         }
     }

--- a/caramel-api/src/test/kotlin/com/whatever/caramel/api/balancegame/controller/BalanceGameControllerTest.kt
+++ b/caramel-api/src/test/kotlin/com/whatever/caramel/api/balancegame/controller/BalanceGameControllerTest.kt
@@ -7,6 +7,7 @@ import com.whatever.caramel.domain.balancegame.vo.BalanceGameOptionVo
 import com.whatever.caramel.domain.balancegame.vo.BalanceGameVo
 import com.whatever.caramel.domain.balancegame.vo.CoupleChoiceOptionVo
 import com.whatever.caramel.domain.balancegame.vo.UserChoiceOptionVo
+import com.whatever.caramel.domain.user.model.UserGender
 import com.whatever.caramel.security.util.SecurityUtil
 import io.mockk.every
 import io.mockk.mockkStatic
@@ -46,7 +47,7 @@ class BalanceGameControllerTest : ControllerTestSupport() {
                 )
             )
         whenever(balanceGameService.getCoupleMemberChoices(any(), any()))
-            .thenReturn(listOf(UserChoiceOptionVo(0L, 0L, 0L, 0L)))
+            .thenReturn(listOf(UserChoiceOptionVo(0L, 0L, 0L, 0L, UserGender.MALE)))
         every { SecurityUtil.getCurrentUserCoupleId() } returns 0L
         every { SecurityUtil.getCurrentUserId() } returns 0L
 

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/repository/UserChoiceOptionRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/repository/UserChoiceOptionRepository.kt
@@ -48,30 +48,14 @@ interface UserChoiceOptionRepository : JpaRepository<UserChoiceOption, Long> {
             where uco.user.id in :memberIds
                 and uco.isDeleted = false
                 and bg.isDeleted = false
-            group by bg.id
-            order by bg.gameDate desc
-        """
-    )
-    fun findRespondedGameIds(
-        memberIds: Collection<Long>,
-        pageable: Pageable,
-    ): List<Long>
-
-    @Query(
-        """
-            select bg.id from UserChoiceOption uco
-                join uco.balanceGame bg
-            where uco.user.id in :memberIds
-                and uco.isDeleted = false
-                and bg.isDeleted = false
-                and bg.gameDate < :cursor
+                and bg.gameDate < :date
             group by bg.id
             order by bg.gameDate desc
         """
     )
     fun findRespondedGameIdsBefore(
         memberIds: Collection<Long>,
-        cursor: LocalDate,
+        date: LocalDate,
         pageable: Pageable,
     ): List<Long>
 

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/repository/UserChoiceOptionRepository.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/repository/UserChoiceOptionRepository.kt
@@ -19,9 +19,10 @@ interface UserChoiceOptionRepository : JpaRepository<UserChoiceOption, Long> {
         """
         select uco from UserChoiceOption uco
             join fetch uco.balanceGameOption
+            join fetch uco.user
         where uco.balanceGame.id = :gameId
             and uco.user.id in :userIds
-            and uco.isDeleted = false 
+            and uco.isDeleted = false
     """
     )
     fun findAllWithOptionByBalanceGameIdAndUsers(
@@ -50,11 +51,13 @@ interface UserChoiceOptionRepository : JpaRepository<UserChoiceOption, Long> {
                 and bg.isDeleted = false
                 and bg.gameDate < :date
             group by bg.id
+            having count(distinct uco.user.id) = :memberCount
             order by bg.gameDate desc
         """
     )
-    fun findRespondedGameIdsBefore(
+    fun findFullyRespondedGameIdsBefore(
         memberIds: Collection<Long>,
+        memberCount: Long,
         date: LocalDate,
         pageable: Pageable,
     ): List<Long>
@@ -62,6 +65,7 @@ interface UserChoiceOptionRepository : JpaRepository<UserChoiceOption, Long> {
     @Query(
         """
             select uco from UserChoiceOption uco
+                join fetch uco.user
             where uco.balanceGame.id in :gameIds
                 and uco.user.id in :memberIds
                 and uco.isDeleted = false

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
@@ -44,20 +44,15 @@ class BalanceGameService(
         queryVo: BalanceGameHistoryQueryVo,
     ): PagedSlice<BalanceGameHistoryVo> {
         val memberIds = getCoupleMemberIds(coupleId)
+        // 진행중인 오늘 게임은 히스토리에서 제외한다. 커서가 있으면 더 과거의 상한을 사용한다.
+        val today = DateTimeUtil.localNow(TARGET_ZONE_ID).toLocalDate()
         val cursorDate = queryVo.cursorDate()
-        val pageable = Pageable.ofSize(queryVo.cursorAwarePageSize())
-        val respondedGameIds = if (cursorDate == null) {
-            userChoiceOptionRepository.findRespondedGameIds(
-                memberIds = memberIds,
-                pageable = pageable,
-            )
-        } else {
-            userChoiceOptionRepository.findRespondedGameIdsBefore(
-                memberIds = memberIds,
-                cursor = cursorDate,
-                pageable = pageable,
-            )
-        }
+        val exclusiveUpperDate = if (cursorDate == null) today else minOf(cursorDate, today)
+        val respondedGameIds = userChoiceOptionRepository.findRespondedGameIdsBefore(
+            memberIds = memberIds,
+            date = exclusiveUpperDate,
+            pageable = Pageable.ofSize(queryVo.cursorAwarePageSize()),
+        )
 
         val gameMap = balanceGameRepository.findAllWithOptionByIds(
             gameIds = respondedGameIds

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameService.kt
@@ -48,8 +48,10 @@ class BalanceGameService(
         val today = DateTimeUtil.localNow(TARGET_ZONE_ID).toLocalDate()
         val cursorDate = queryVo.cursorDate()
         val exclusiveUpperDate = if (cursorDate == null) today else minOf(cursorDate, today)
-        val respondedGameIds = userChoiceOptionRepository.findRespondedGameIdsBefore(
+        // 커플 멤버가 모두 응답한 게임만 히스토리에 노출한다.
+        val respondedGameIds = userChoiceOptionRepository.findFullyRespondedGameIdsBefore(
             memberIds = memberIds,
+            memberCount = memberIds.size.toLong(),
             date = exclusiveUpperDate,
             pageable = Pageable.ofSize(queryVo.cursorAwarePageSize()),
         )

--- a/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/vo/UserChoiceOptionVo.kt
+++ b/caramel-domain/src/main/kotlin/com/whatever/caramel/domain/balancegame/vo/UserChoiceOptionVo.kt
@@ -1,6 +1,7 @@
 package com.whatever.caramel.domain.balancegame.vo
 
 import com.whatever.caramel.domain.balancegame.model.UserChoiceOption
+import com.whatever.caramel.domain.user.model.UserGender
 
 data class UserChoiceOptionVo(
     val id: Long = 0L,
@@ -10,6 +11,8 @@ data class UserChoiceOptionVo(
     val balanceGameOptionId: Long,
 
     val userId: Long,
+
+    val gender: UserGender,
 ) {
 
     companion object {
@@ -19,6 +22,7 @@ data class UserChoiceOptionVo(
                 balanceGameId = userChoiceOption.balanceGame.id,
                 balanceGameOptionId = userChoiceOption.balanceGameOption.id,
                 userId = userChoiceOption.user.id,
+                gender = userChoiceOption.user.gender!!
             )
         }
     }

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -22,6 +22,7 @@ import com.whatever.caramel.domain.calendarevent.scheduleevent.service.createCou
 import com.whatever.caramel.domain.couple.model.Couple
 import com.whatever.caramel.domain.couple.repository.CoupleRepository
 import com.whatever.caramel.domain.user.model.User
+import com.whatever.caramel.domain.user.model.UserGender
 import com.whatever.caramel.domain.user.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -469,11 +470,14 @@ class BalanceGameServiceTest @Autowired constructor(
     @Test
     fun getBalanceGameHistory_WhenMoreThanPageSizeReturnsNextCursor() {
         // given
-        val (myUser, _, couple) = setUpCouple()
+        val (myUser, partnerUser, couple) = setUpCouple()
         val games = makeBalanceGame(5, LocalDate.of(2025, 5, 1)) // 05-01 ~ 05-05
         games.forEach { (game, options) ->
             userChoiceOptionRepository.save(
                 UserChoiceOption(balanceGame = game, balanceGameOption = options.first(), user = myUser)
+            )
+            userChoiceOptionRepository.save(
+                UserChoiceOption(balanceGame = game, balanceGameOption = options.last(), user = partnerUser)
             )
         }
         val queryVo = BalanceGameHistoryQueryVo(
@@ -572,40 +576,18 @@ class BalanceGameServiceTest @Autowired constructor(
         assertThat(result.cursor.next).isNull()
     }
 
-    @DisplayName("밸런스 게임 히스토리 조회 시 나만 응답한 게임은 partnerChoice가 null이다.")
+    @DisplayName("밸런스 게임 히스토리 조회 시 커플 중 한 명만 응답한 게임은 히스토리에서 제외된다.")
     @Test
-    fun getBalanceGameHistory_WhenOnlyMeRespondedPartnerChoiceIsNull() {
-        // given
-        val (myUser, _, couple) = setUpCouple()
-        val (game, options) = makeBalanceGame(1, LocalDate.of(2025, 5, 1)).first()
-        val myChoice = userChoiceOptionRepository.save(
-            UserChoiceOption(balanceGame = game, balanceGameOption = options.first(), user = myUser)
-        )
-        val queryVo = BalanceGameHistoryQueryVo(
-            size = 10,
-            cursor = null,
-            sortType = BalanceGameHistorySortType.GAME_DATE_DESC,
-        )
-
-        // when
-        val result = balanceGameService.getBalanceGameHistory(myUser.id, couple.id, queryVo)
-
-        // then
-        assertThat(result.list).hasSize(1)
-        val choice = result.list.first().coupleChoiceOption
-        assertThat(choice.myChoice).isNotNull
-        assertThat(choice.myChoice!!.balanceGameOptionId).isEqualTo(myChoice.balanceGameOption.id)
-        assertThat(choice.partnerChoice).isNull()
-    }
-
-    @DisplayName("밸런스 게임 히스토리 조회 시 파트너만 응답한 게임도 포함되며 myChoice가 null이다.")
-    @Test
-    fun getBalanceGameHistory_WhenOnlyPartnerRespondedMyChoiceIsNull() {
+    fun getBalanceGameHistory_ExcludesGamesAnsweredByOnlyOneMember() {
         // given
         val (myUser, partnerUser, couple) = setUpCouple()
-        val (game, options) = makeBalanceGame(1, LocalDate.of(2025, 5, 1)).first()
-        val partnerChoice = userChoiceOptionRepository.save(
-            UserChoiceOption(balanceGame = game, balanceGameOption = options.first(), user = partnerUser)
+        val games = makeBalanceGame(2, LocalDate.of(2025, 5, 1)) // 05-01, 05-02
+        // 05-01: 나만 응답, 05-02: 파트너만 응답 -> 둘 다 양쪽 응답이 아님
+        userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[0].first, balanceGameOption = games[0].second.first(), user = myUser)
+        )
+        userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[1].first, balanceGameOption = games[1].second.first(), user = partnerUser)
         )
         val queryVo = BalanceGameHistoryQueryVo(
             size = 10,
@@ -617,12 +599,7 @@ class BalanceGameServiceTest @Autowired constructor(
         val result = balanceGameService.getBalanceGameHistory(myUser.id, couple.id, queryVo)
 
         // then
-        assertThat(result.list).hasSize(1)
-        val choice = result.list.first().coupleChoiceOption
-        assertThat(choice.myChoice).isNull()
-        assertThat(choice.partnerChoice).isNotNull
-        assertThat(choice.partnerChoice!!.userId).isEqualTo(partnerUser.id)
-        assertThat(choice.partnerChoice!!.balanceGameOptionId).isEqualTo(partnerChoice.balanceGameOption.id)
+        assertThat(result.list).isEmpty()
     }
 
     @DisplayName("밸런스 게임 히스토리 조회 시 커플 모두 응답한 게임은 my/partner 선택이 모두 매핑된다.")
@@ -677,17 +654,25 @@ class BalanceGameServiceTest @Autowired constructor(
         assertThat(result.cursor.next).isNull()
     }
 
-    @DisplayName("밸런스 게임 히스토리 조회 시 soft delete된 응답만 있는 게임은 히스토리에서 제외된다.")
+    @DisplayName("밸런스 게임 히스토리 조회 시 양쪽 응답 중 하나가 soft delete되면 해당 게임은 제외된다.")
     @Test
-    fun getBalanceGameHistory_WhenChoiceSoftDeletedExcludesGame() {
+    fun getBalanceGameHistory_WhenOneOfBothChoicesSoftDeletedExcludesGame() {
         // given
-        val (myUser, _, couple) = setUpCouple()
+        val (myUser, partnerUser, couple) = setUpCouple()
         val games = makeBalanceGame(2, LocalDate.of(2025, 5, 1)) // 05-01, 05-02
+        // 05-01: 양쪽 응답 (포함되어야 함)
         userChoiceOptionRepository.save(
             UserChoiceOption(balanceGame = games[0].first, balanceGameOption = games[0].second.first(), user = myUser)
         )
-        val deletedChoice = userChoiceOptionRepository.save(
+        userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[0].first, balanceGameOption = games[0].second.last(), user = partnerUser)
+        )
+        // 05-02: 양쪽 응답했지만 파트너 응답을 soft delete -> 활성 응답 1명 -> 제외
+        userChoiceOptionRepository.save(
             UserChoiceOption(balanceGame = games[1].first, balanceGameOption = games[1].second.first(), user = myUser)
+        )
+        val deletedChoice = userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[1].first, balanceGameOption = games[1].second.last(), user = partnerUser)
         )
         deletedChoice.deleteEntity()
         userChoiceOptionRepository.save(deletedChoice)
@@ -705,17 +690,27 @@ class BalanceGameServiceTest @Autowired constructor(
         assertThat(result.list.first().balanceGame.gameDate).isEqualTo(games[0].first.gameDate)
     }
 
-    @DisplayName("밸런스 게임 히스토리 조회 시 응답한 게임만 포함되고 미응답 게임은 제외된다.")
+    @DisplayName("밸런스 게임 히스토리 조회 시 양쪽이 모두 응답한 게임만 gameDate 내림차순으로 내려온다.")
     @Test
-    fun getBalanceGameHistory_OnlyRespondedGamesIncluded() {
+    fun getBalanceGameHistory_IncludesOnlyGamesBothAnswered() {
         // given
-        val (myUser, _, couple) = setUpCouple()
+        val (myUser, partnerUser, couple) = setUpCouple()
         val games = makeBalanceGame(3, LocalDate.of(2025, 5, 1)) // 05-01, 05-02, 05-03
+        // 05-01: 양쪽, 05-02: 나만, 05-03: 양쪽 -> 05-03, 05-01 만 노출
         userChoiceOptionRepository.save(
             UserChoiceOption(balanceGame = games[0].first, balanceGameOption = games[0].second.first(), user = myUser)
         )
         userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[0].first, balanceGameOption = games[0].second.last(), user = partnerUser)
+        )
+        userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[1].first, balanceGameOption = games[1].second.first(), user = myUser)
+        )
+        userChoiceOptionRepository.save(
             UserChoiceOption(balanceGame = games[2].first, balanceGameOption = games[2].second.first(), user = myUser)
+        )
+        userChoiceOptionRepository.save(
+            UserChoiceOption(balanceGame = games[2].first, balanceGameOption = games[2].second.last(), user = partnerUser)
         )
         val queryVo = BalanceGameHistoryQueryVo(
             size = 10,
@@ -737,7 +732,7 @@ class BalanceGameServiceTest @Autowired constructor(
     @Test
     fun getBalanceGameHistory_ExcludesTodayGame() {
         // given
-        val (myUser, _, couple) = setUpCouple()
+        val (myUser, partnerUser, couple) = setUpCouple()
         val now = LocalDateTime.of(2025, 5, 5, 9, 0)
         mockStatic(DateTimeUtil::class.java).use {
             whenever(DateTimeUtil.localNow(any())).thenReturn(now)
@@ -745,6 +740,9 @@ class BalanceGameServiceTest @Autowired constructor(
             games.forEach { (game, options) ->
                 userChoiceOptionRepository.save(
                     UserChoiceOption(balanceGame = game, balanceGameOption = options.first(), user = myUser)
+                )
+                userChoiceOptionRepository.save(
+                    UserChoiceOption(balanceGame = game, balanceGameOption = options.last(), user = partnerUser)
                 )
             }
             val queryVo = BalanceGameHistoryQueryVo(
@@ -772,6 +770,11 @@ class BalanceGameServiceTest @Autowired constructor(
             myPlatformId,
             partnerPlatformId
         )
+        // 커플 멤버는 register 시 gender가 필수이므로 테스트에서도 gender를 부여한다.
+        myUser.gender = UserGender.MALE
+        partnerUser.gender = UserGender.FEMALE
+        userRepository.save(myUser)
+        userRepository.save(partnerUser)
         return Triple(myUser, partnerUser, couple)
     }
 

--- a/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
+++ b/caramel-domain/src/test/kotlin/com/whatever/caramel/domain/balancegame/service/BalanceGameServiceTest.kt
@@ -733,6 +733,35 @@ class BalanceGameServiceTest @Autowired constructor(
         )
     }
 
+    @DisplayName("밸런스 게임 히스토리 조회 시 진행중인 오늘 게임은 응답했더라도 히스토리에서 제외된다.")
+    @Test
+    fun getBalanceGameHistory_ExcludesTodayGame() {
+        // given
+        val (myUser, _, couple) = setUpCouple()
+        val now = LocalDateTime.of(2025, 5, 5, 9, 0)
+        mockStatic(DateTimeUtil::class.java).use {
+            whenever(DateTimeUtil.localNow(any())).thenReturn(now)
+            val games = makeBalanceGame(2, LocalDate.of(2025, 5, 4)) // 05-04(어제), 05-05(오늘)
+            games.forEach { (game, options) ->
+                userChoiceOptionRepository.save(
+                    UserChoiceOption(balanceGame = game, balanceGameOption = options.first(), user = myUser)
+                )
+            }
+            val queryVo = BalanceGameHistoryQueryVo(
+                size = 10,
+                cursor = null,
+                sortType = BalanceGameHistorySortType.GAME_DATE_DESC,
+            )
+
+            // when
+            val result = balanceGameService.getBalanceGameHistory(myUser.id, couple.id, queryVo)
+
+            // then
+            assertThat(result.list).hasSize(1)
+            assertThat(result.list.first().balanceGame.gameDate).isEqualTo(LocalDate.of(2025, 5, 4))
+        }
+    }
+
     private fun setUpCouple(
         myPlatformId: String = "my-user-id",
         partnerPlatformId: String = "partner-user-id",


### PR DESCRIPTION
## 관련 이슈
- 

## 작업한 내용
- OptionInfo 객체에 유저 성별 졍보를 추가
  - 선택 endpoint는 성별이 null로 나감
- 커플 멤버가 모두 선택한 게임만 history로 전송

## PR 포인트
- 